### PR TITLE
add WORKDIR to centos-quarkus-native-s2i/Dockerfile

### DIFF
--- a/centos-quarkus-native-s2i/Dockerfile
+++ b/centos-quarkus-native-s2i/Dockerfile
@@ -60,6 +60,8 @@ ENV PATH=$PATH:"/usr/local/s2i"
 
 USER 1001
 
+WORKDIR ${QUARKUS_HOME}
+
 EXPOSE 8080
 
 # Use the run script as default since we are working as an hybrid image which can be


### PR DESCRIPTION
suggested on https://github.com/josequaresma/quarkus/commit/5d357f75d84e0eed3456d35f59f98d34aaf55705 by @josequaresma and should "remove the error with application not being able to create quarkus.log" which was brought up on #1 (according to @josequaresma)