### PR TITLE
Allow configuring the working dir for `assemble`

### DIFF
--- a/modules/quarkus-native-s2i-scripts/s2i/assemble
+++ b/modules/quarkus-native-s2i-scripts/s2i/assemble
@@ -16,7 +16,9 @@ CONFIGURE_SCRIPTS=(
 source ${QUARKUS_HOME}/.m2/configure.sh
 #############################################
 
-cd /tmp/src/
+SRC_DIR=${SRC_DIR:-'/tmp/src/'}
+
+cd $SRC_DIR
 
 if [ -e ./pom.xml -a -z "$USE_GRADLE" ]; then
     USE_GRADLE=false


### PR DESCRIPTION
The assemble script wil use the working directory via `SRC_DIR` env var