### PR TITLE
Add script to update quay.io with latest description

### DIFF
--- a/updatequay.py
+++ b/updatequay.py
@@ -1,0 +1,45 @@
+## Update description by parsing Cekit yaml and extract io.k8s.description
+## and updating repo via quay.io api.
+## Require application token from an organization that have write access.
+
+import requests
+import yaml
+
+from argparse import ArgumentParser
+
+parser = ArgumentParser()
+parser.add_argument('files', metavar="Files", type=str, nargs="+", help="File to extract metadata from.")
+parser.add_argument('--token', metavar="Token", type=str, required=True, help="quay.io token that has write access.")
+args = parser.parse_args()
+
+
+for f in args.files:
+
+    with open(f, 'r') as stream:
+        try:
+            data = yaml.safe_load(stream)
+        except yaml.YAMLError as exc:
+            print("Error parsing: " + f)
+
+    if data:
+        name = data['name']
+        if name.startswith("quay.io/"):
+            name = name[len("quay.io/"):]
+
+            repoapiurl = 'https://quay.io/api/v1/repository/' + name
+            
+            reallabels = data['labels']
+            labels = {}
+            for l in reallabels:
+                labels[l["name"]] = l["value"]
+
+            description = labels["io.k8s.description"] + "\n\n\n[Source](https://github.com/quarkusio/quarkus-images)"
+
+            print("Setting '{0}' description to '{1}'".format(name, description))
+            r = requests.put(repoapiurl,
+                             headers={'Content-Type': 'application/json', 'Authorization': 'Bearer ' + args.token},
+                             json={"description":description})
+
+            print(r.text)
+        else:
+            print("Skipping " + f + " as not referencing quay.io")


### PR DESCRIPTION
Go create a application and get its token and run it as:

`python3 updatequay.py --token <secret> *-overrides.yaml`

and you should get some output like:

```
Setting 'quarkus/centos-quarkus-maven' description to 'Quarkus.io builder image for building Quarkus applications.


[Source](https://github.com/quarkusio/quarkus-images)'

Setting 'quarkus/ubi-quarkus-native-binary-s2i' description to 'Quarkus.io S2I image for running native images on Red Hat UBI 8


[Source](https://github.com/quarkusio/quarkus-images)'

Setting 'quarkus/ubi-quarkus-native-image' description to 'Quarkus.io executable image providing the `native-image` executable.


[Source](https://github.com/quarkusio/quarkus-images)'

Setting 'quarkus/ubi-quarkus-native-s2i' description to 'Quarkus.io S2I image for building Kubernetes Native Java GraalVM applications and running its Native Executables


[Source](https://github.com/quarkusio/quarkus-images)'
```

And https://quay.io/organization/quarkus should instantly look more informative :)