### PR TITLE
Fixed minor image link issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To pull these images use:
 * `docker pull quay.io/quarkus/ubi-quarkus-native-s2i:VERSION`
 * `docker pull quay.io/quarkus/centos-quarkus-maven:VERSION`
 * `docker pull quay.io/quarkus/ubi-quarkus-native-s2i:VERSION`
-* `docker pull quay.io/quarkus/ubi-quarkus-native-s2i:VERSION`
+* `docker pull quay.io/quarkus/ubi-quarkus-native-binary-s2i:VERSION`
 
 with _VERSION_ the version. 
 The version matches the GraalVM version used in the image, for example: `19.2.0.1`.


### PR DESCRIPTION
Fixed an issue where the link to download the ubi-quarkus-native-binary-s2i was missing.