### PR TITLE
set ubi version to 8.0

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 
 name: "quay.io/quarkus/image-name-from-overrides-file"
 version: "19.3.0.2"
-from: "registry.access.redhat.com/ubi8/ubi-minimal:latest"
+from: "registry.access.redhat.com/ubi8/ubi-minimal:8.0"
 
 labels:
 - name: "maintainer"


### PR DESCRIPTION
This is because https://github.com/cekit/cekit/issues/637 and https://github.com/rpm-software-management/microdnf/issues/50 breaking microdnf in ubi 8.1.