### PR TITLE
Fix ubi-quarkus-native-image docker image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The images are available on [Quay.io](https://quay.io/organization/quarkus)
 
 To pull these images use:
 
-* `docker pull quay.io/quarkus/ubi-quarkus-native-s2i:VERSION`
+* `docker pull quay.io/quarkus/ubi-quarkus-native-image:VERSION`
 * `docker pull quay.io/quarkus/centos-quarkus-maven:VERSION`
 * `docker pull quay.io/quarkus/ubi-quarkus-native-s2i:VERSION`
 * `docker pull quay.io/quarkus/ubi-quarkus-native-binary-s2i:VERSION`


### PR DESCRIPTION
Hello,
The `ubi-quarkus-native-image` image was missing and the `ubi-quarkus-native-s2i` duplicated in the readme.
Does this change make sense?