### PR TITLE
Update README.md

### DIFF
--- a/distroless/README.md
+++ b/distroless/README.md
@@ -28,7 +28,7 @@ Then, create the following `Dockerfile`:
 
 ```dockerfile
 FROM cescoffier/native-base:latest
-COPY target/*-runner /application
+COPY build/*-runner /application
 EXPOSE 8080
 CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
 ```


### PR DESCRIPTION
at least with quarkus 1.2.1 (latest) the native file is in the `build` subdir.