### PR TITLE
fix(volume): Avoid to declare the volume in the image

### DIFF
--- a/quarkus-tooling.yaml
+++ b/quarkus-tooling.yaml
@@ -59,10 +59,6 @@ envs:
 - name: "PATH"
   value: "$PATH:$JAVA_HOME/bin"  
 
-volumes:
-- name: "volume.project"
-  path: "/project"
-
 run:
   user: 1001
   workdir: "/project"


### PR DESCRIPTION
Volumes are not mandatory in the Docker image

But for example it is making issues on Eclipse Che running on OpenShift as we don't have corresponding mount and do not have permissions on that folder. (`/project`)

https://docs.openshift.com/container-platform/3.11/install/host_preparation.html#blocking-local-volume-usage

Change-Id: I801488fb3e855df645f1be7d9cde96cfd41209f7
Signed-off-by: Florent Benoit <fbenoit@redhat.com>