### PR TITLE
Move s2i scripts to /usr/libexec/s2i

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ buildNumber.properties
 
 # Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
 !/.mvn/wrapper/maven-wrapper.jar
+.cekit

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ We recommend using `virtualenv` to run `cekit`.
 On MacOS X, you can run the build as follows:
 
 ```bash
-virtualenv --python=python3 ~/cekit
-source ~/cekit/bin/activate
+virtualenv --python=python3 .cekit
+source .cekit/bin/activate
 pip install -U cekit
 pip install odcs
 pip install docker
@@ -133,25 +133,14 @@ For other Systems, please refer to the docs.
 
 
 ###### Build:
-Build + squash
 
-```bash
-$ make
-```
+The build scripts are located in the `.github` directory:
 
-
-###### Testing:
-This step will build (squashing) and test the images
-```bash
-$ make test
-```
-
-###### Push the images:
-This step will build (squashing), test and push the images to quay.io/quarkus
-This step requires the write permission for the Quarkus organization on Quay.io.
-```bash
-make push
-```
+* `build-mandrel-images.sh` - build the mandrel images
+* `build-native-images.sh` - build the images providing the `native-image` executable
+* `build-s2i-binary-images.sh` - build the s2i builder images taking a pre-built native executable
+* `build-s2i-native-images.sh` - build the s2i builder images taking Java sources as input and building the native exectuable and the container
+* `build-tooling-images.sh` - build the tooling image
 
 # Continuous Integration and Automation
 

--- a/modules/quarkus-native-binary-s2i-scripts/configure
+++ b/modules/quarkus-native-binary-s2i-scripts/configure
@@ -3,6 +3,6 @@ set -e
 
 SCRIPT_DIR=$(dirname $0)
 
-cp -rv ${SCRIPT_DIR}/s2i /usr/local/s2i
+cp -rv ${SCRIPT_DIR}/s2i /usr/libexec/s2i
 
-chmod 755 -R /usr/local/s2i/
+chmod 755 -R /usr/libexec/s2i

--- a/modules/quarkus-native-binary-s2i-scripts/s2i/usage
+++ b/modules/quarkus-native-binary-s2i-scripts/s2i/usage
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 cat <<EOF
-This is an Quarkus UBI8 S2I image that can take an uploaded native binary and deploy it on top of a UBI7 minimal image. You can override the default parameters by setting the "QUARKUS_OPTS" environment variable. This image only support uploading a binary file or a directory with a binary file that ends with matches *-runner. It is not capable of build source to image. For that use the centos-quarkus-native-s2i image.
+This is an Quarkus UBI8 S2I image that can take an uploaded native binary and deploy it on top of a UBI7 minimal image. You can override the default parameters by setting the "QUARKUS_OPTS" environment variable. This image only support uploading a binary file or a directory with a binary file that ends with matches *-runner. It is not capable of build source to image. For that use the quay.io/quarkus/ubi-quarkus-native-s2i image.
 EOF

--- a/modules/quarkus-native-s2i-scripts/configure
+++ b/modules/quarkus-native-s2i-scripts/configure
@@ -3,9 +3,9 @@ set -e
 
 SCRIPT_DIR=$(dirname $0)
 
-cp -rv ${SCRIPT_DIR}/s2i /usr/local/s2i
-cp -rv ${SCRIPT_DIR}/README.md /usr/local/s2i/usage.txt
+cp -rv ${SCRIPT_DIR}/s2i /usr/libexec/s2i
+cp -rv ${SCRIPT_DIR}/README.md /usr/libexec/s2i/usage.txt
 
 mkdir /project
 
-chmod 755 -R /usr/local/s2i/ /project
+chmod 755 -R /usr/libexec/s2i/ /project

--- a/quarkus-native-binary-s2i.yaml
+++ b/quarkus-native-binary-s2i.yaml
@@ -6,7 +6,7 @@ version: "SNAPSHOT"
 
 labels:
 - name: "io.openshift.s2i.scripts-url"
-  value: "image:///usr/local/s2i"
+  value: "image:///usr/libexec/s2i"
 - name: "io.openshift.s2i.destination"
   value: "/tmp"
 - name: "io.openshift.expose-services"
@@ -43,4 +43,4 @@ run:
   user: 1001
   workdir: "${QUARKUS_HOME}"
   cmd:
-  - "/usr/local/s2i/usage"
+  - "/usr/libexec/s2i/usage"

--- a/quarkus-native-s2i.yaml
+++ b/quarkus-native-s2i.yaml
@@ -5,7 +5,7 @@ version: "SNAPSHOT"
 
 labels:
 - name: "io.openshift.s2i.scripts-url"
-  value: "image:///usr/local/s2i"
+  value: "image:///usr/libexec/s2i"
 - name: "io.openshift.s2i.destination"
   value: "/tmp"
 - name: "io.openshift.expose-services"
@@ -51,5 +51,5 @@ run:
   user: 1001
   workdir: "${QUARKUS_HOME}"
   cmd:
-  - "/usr/local/s2i/run"
+  - "/usr/libexec/s2i/run"
 


### PR DESCRIPTION

Fix #85:

﻿- Update outdated build instructions
- Move s2i scripts to /usr/libexec/s2i
