### PR TITLE
Create floating tag for each major.minor version of GraalVM

### DIFF
--- a/.github/build-mandrel-images.sh
+++ b/.github/build-mandrel-images.sh
@@ -18,10 +18,13 @@ do
 done
 
 # Get all the final versions, reverse sort them, and keep only the first for each major.minor (e.g. 20.1)
-LATEST_FINAL_VERSIONS=$(sed 's/ /\n/g' <<< ${VERSIONS[@]} | grep Final | sort -r | sort -k1,1 -k2,2 -k5,5 -t'.' --unique)
+LATEST_FINAL_VERSIONS=$(tr ' ' '\n'  <<< "${VERSIONS[@]}" | grep Final | sort -r | sort -k1,1 -k2,2 -k5,5 -t'.' --unique)
 for latest in ${LATEST_FINAL_VERSIONS[@]}
 do
-    ${BUILD_ENGINE} tag ${PREFIX_NAME}:${latest} ${PREFIX_NAME}:${latest/.[^.].[^.].Final/}
+    major=`echo $latest | cut -d. -f1`
+    minor=`echo $latest | cut -d. -f2`
+    tag=${major}.${minor}-java11
+    ${BUILD_ENGINE} tag ${PREFIX_NAME}:${latest} ${PREFIX_NAME}:${tag}
 done
 
 ${BUILD_ENGINE} image prune -f

--- a/.github/build-native-images.sh
+++ b/.github/build-native-images.sh
@@ -17,5 +17,31 @@ do
         ${BUILD_ENGINE} --tag="${PREFIX_NAME}:${version}"
 done
 
+# Create floating tags
+# For example 19.3-java8, 20.0-java8, 20.0-java11
+# The tag target the latest minors. So if there are versions 19.3.2 and 19.3.3, it will create a tag pointing to 19.3.3 named 19.3-java[8|11]
+
+# Get all the versions, reverse sort them, and keep only the first for each major.minor (e.g. 20.1)
+LATEST_JAVA8_VERSIONS=$(tr ' ' '\n'  <<< "${VERSIONS[@]}" | grep java8 | sort -r | sort -k1,1 -k2,2 -k5,5 -t'.' --unique)
+LATEST_JAVA11_VERSIONS=$(tr ' ' '\n'  <<< "${VERSIONS[@]}" | grep java11 | sort -r | sort -k1,1 -k2,2 -k5,5 -t'.' --unique)
+# Create the tags
+for latest in ${LATEST_JAVA8_VERSIONS[@]}
+do
+    major=`echo $latest | cut -d. -f1`
+    minor=`echo $latest | cut -d. -f2`
+    tag=${major}.${minor}-java8
+    echo "Creating tag for ${latest} : ${tag}" 
+    ${BUILD_ENGINE} tag ${PREFIX_NAME}:${latest} ${PREFIX_NAME}:${tag}
+done
+
+for latest in ${LATEST_JAVA11_VERSIONS[@]}
+do
+    major=`echo $latest | cut -d. -f1`
+    minor=`echo $latest | cut -d. -f2`
+    tag=${major}.${minor}-java11
+    echo "Creating tag for ${latest} : ${tag}" 
+    ${BUILD_ENGINE} tag ${PREFIX_NAME}:${latest} ${PREFIX_NAME}:${tag}
+done
+
 docker image prune -f
 docker images  

--- a/.github/build-s2i-native-images.sh
+++ b/.github/build-s2i-native-images.sh
@@ -17,5 +17,31 @@ do
         ${BUILD_ENGINE} --tag="${PREFIX_NAME}:${version}"
 done
 
+# Create floating tags
+# For example 19.3-java8, 20.0-java8, 20.0-java11
+# The tag target the latest minors. So if there are versions 19.3.2 and 19.3.3, it will create a tag pointing to 19.3.3 named 19.3-java[8|11]
+
+# Get all the versions, reverse sort them, and keep only the first for each major.minor (e.g. 20.1)
+LATEST_JAVA8_VERSIONS=$(tr ' ' '\n'  <<< "${VERSIONS[@]}" | grep java8 | sort -r | sort -k1,1 -k2,2 -k5,5 -t'.' --unique)
+LATEST_JAVA11_VERSIONS=$(tr ' ' '\n'  <<< "${VERSIONS[@]}" | grep java11 | sort -r | sort -k1,1 -k2,2 -k5,5 -t'.' --unique)
+# Create the tags
+for latest in ${LATEST_JAVA8_VERSIONS[@]}
+do
+    major=`echo $latest | cut -d. -f1`
+    minor=`echo $latest | cut -d. -f2`
+    tag=${major}.${minor}-java8
+    echo "Creating tag for ${latest} : ${tag}" 
+    ${BUILD_ENGINE} tag ${PREFIX_NAME}:${latest} ${PREFIX_NAME}:${tag}
+done
+
+for latest in ${LATEST_JAVA11_VERSIONS[@]}
+do
+    major=`echo $latest | cut -d. -f1`
+    minor=`echo $latest | cut -d. -f2`
+    tag=${major}.${minor}-java11
+    echo "Creating tag for ${latest} : ${tag}" 
+    ${BUILD_ENGINE} tag ${PREFIX_NAME}:${latest} ${PREFIX_NAME}:${tag}
+done
+
 docker image prune -f
 docker images  

--- a/.github/build-tooling-images.sh
+++ b/.github/build-tooling-images.sh
@@ -17,5 +17,31 @@ do
         ${BUILD_ENGINE} --tag="${PREFIX_NAME}:${version}"
 done
 
+# Create floating tags
+# For example 19.3-java8, 20.0-java8, 20.0-java11
+# The tag target the latest minors. So if there are versions 19.3.2 and 19.3.3, it will create a tag pointing to 19.3.3 named 19.3-java[8|11]
+
+# Get all the versions, reverse sort them, and keep only the first for each major.minor (e.g. 20.1)
+LATEST_JAVA8_VERSIONS=$(tr ' ' '\n'  <<< "${VERSIONS[@]}" | grep java8 | sort -r | sort -k1,1 -k2,2 -k5,5 -t'.' --unique)
+LATEST_JAVA11_VERSIONS=$(tr ' ' '\n'  <<< "${VERSIONS[@]}" | grep java11 | sort -r | sort -k1,1 -k2,2 -k5,5 -t'.' --unique)
+# Create the tags
+for latest in ${LATEST_JAVA8_VERSIONS[@]}
+do
+    major=`echo $latest | cut -d. -f1`
+    minor=`echo $latest | cut -d. -f2`
+    tag=${major}.${minor}-java8
+    echo "Creating tag for ${latest} : ${tag}" 
+    ${BUILD_ENGINE} tag ${PREFIX_NAME}:${latest} ${PREFIX_NAME}:${tag}
+done
+
+for latest in ${LATEST_JAVA11_VERSIONS[@]}
+do
+    major=`echo $latest | cut -d. -f1`
+    minor=`echo $latest | cut -d. -f2`
+    tag=${major}.${minor}-java11
+    echo "Creating tag for ${latest} : ${tag}" 
+    ${BUILD_ENGINE} tag ${PREFIX_NAME}:${latest} ${PREFIX_NAME}:${tag}
+done
+
 docker image prune -f
 docker images


### PR DESCRIPTION
Update the build script to create floating tags for each image versioned using the GraalVM version.
The tags are using the following syntax: `major.minor﻿-java[8|11]`


