### PR TITLE
Adds Mandrel 20.2.0.0.Final release

### DIFF
--- a/.github/mandrel-images.yaml
+++ b/.github/mandrel-images.yaml
@@ -9,9 +9,10 @@ versions:
   - 20.1.0.3.Final-java11
   - 20.2.0.0.Beta1-java11
   - 20.2.0.0.Beta2-java11
+  - 20.2.0.0.Final-java11
 tags:
   - id: 20.1-java11
     target: 20.1.0.3.Final-java11
   - id: 20.2-java11
-    target: 20.2.0.0.Beta2-java11
+    target: 20.2.0.0.Final-java11
 versionCheck: true

--- a/modules/mandrel/20.2.0.0.Final-java11/configure
+++ b/modules/mandrel/20.2.0.0.Final-java11/configure
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+SOURCES_DIR=/tmp/artifacts
+
+ls -l ${SOURCES_DIR}
+mkdir -p ${GRAALVM_HOME}
+tar xzf ${SOURCES_DIR}/${FILENAME} -C ${GRAALVM_HOME} --strip-components=1

--- a/modules/mandrel/20.2.0.0.Final-java11/module.yaml
+++ b/modules/mandrel/20.2.0.0.Final-java11/module.yaml
@@ -1,0 +1,25 @@
+schema_version: 1
+name: mandrel
+version: &version "20.2.0.0.Final-java11"
+
+labels:
+  - name: mandrel-archive-filename
+    value: &filename mandrel-java11-linux-amd64-20.2.0.0.Final.tar.gz
+  - name: mandrel-archive-url
+    value: &url https://github.com/graalvm/mandrel/releases/download/mandrel-20.2.0.0.Final/mandrel-java11-linux-amd64-20.2.0.0.Final.tar.gz
+
+envs:
+  - name: "JAVA_HOME"
+    value: "/opt/mandrel"
+  - name: "GRAALVM_HOME"
+    value: "/opt/mandrel"
+  - name: "FILENAME"
+    value: *filename
+
+artifacts:
+- name: *filename
+  url: *url
+  md5: 9d4a2990cd8d974bcd22846a3b96135d
+
+execute:
+- script: configure


### PR DESCRIPTION
* Upgrades to the latest OpenJDK 11.0.9 GA.
* See release notes: https://github.com/graalvm/mandrel/releases/tag/mandrel-20.2.0.0.Final

ping @jerboaa  @zakkak 