### PR TITLE
Add support for GraalVM 2.3.0

### DIFF
--- a/.github/native-images.yaml
+++ b/.github/native-images.yaml
@@ -4,9 +4,12 @@ buildScript: .github/build-native-images.sh
 versions:
   - 20.1.0-java11
   - 20.2.0-java11
+  - 20.3.0-java11
 tags:
   - id: 20.1-java11
     target: 20.1.0-java11
   - id: 20.2-java11
     target: 20.2.0-java11
+  - id: 20.3-java11
+    target: 20.3.0-java11    
 versionCheck: true

--- a/.github/s2i-native-images.yaml
+++ b/.github/s2i-native-images.yaml
@@ -4,9 +4,12 @@ buildScript: .github/build-s2i-native-images.sh
 versions:
   - 20.1.0-java11
   - 20.2.0-java11
+  - 20.3.0-java11
 tags:
   - id: 20.1-java11
     target: 20.1.0-java11
   - id: 20.2-java11
     target: 20.2.0-java11
+  - id: 20.3-java11
+    target: 20.3.0-java11    
 versionCheck: false

--- a/.github/tooling-images.yaml
+++ b/.github/tooling-images.yaml
@@ -2,11 +2,11 @@ image: quarkus-tooling.yaml
 imageName: quay.io/quarkus/centos-quarkus-maven
 buildScript: .github/build-tooling-images.sh
 versions:
-  - 20.1.0-java11
   - 20.2.0-java11
+  - 20.3.0-java11
 tags:
-  - id: 20.1-java11
-    target: 20.1.0-java11
   - id: 20.2-java11
     target: 20.2.0-java11
+  - id: 20.3-java11
+    target: 20.3.0-java11    
 versionCheck: false

--- a/modules/graalvm/20.3.0-java11/configure
+++ b/modules/graalvm/20.3.0-java11/configure
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+SOURCES_DIR=/tmp/artifacts
+
+ls -l ${SOURCES_DIR}
+tar xzf ${SOURCES_DIR}/${FILENAME} -C /opt
+mv /opt/graalvm-ce-${GRAALVM_VERSION} /opt/graalvm
+
+echo "Installing native-image"
+/opt/graalvm/bin/gu --auto-yes install native-image

--- a/modules/graalvm/20.3.0-java11/module.yaml
+++ b/modules/graalvm/20.3.0-java11/module.yaml
@@ -1,0 +1,29 @@
+schema_version: 1
+name: graalvm
+version: &version "20.3.0-java11"
+
+labels:
+  - name: graalvm-archive-filename
+    value: &filename graalvm-ce-linux-amd64-20.3.0-java11.tar.gz
+  - name: graalvm-archive-url
+    value: &url https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.3.0/graalvm-ce-java11-linux-amd64-20.3.0.tar.gz
+  - name: graalvm-version
+    value:   &suffix java11-20.3.0
+
+envs:
+  - name: "JAVA_HOME"
+    value: "/opt/graalvm"
+  - name: "GRAALVM_HOME"
+    value: "/opt/graalvm"
+  - name: "GRAALVM_VERSION"
+    value: *suffix
+  - name: "FILENAME"  
+    value: *filename
+
+artifacts:
+- name: *filename
+  url: *url
+  md5: 7bdd85e00c1e80530d711c8a2e61a153
+
+execute:
+- script: configure


### PR DESCRIPTION
Add support for GraalVM 2.3.0


* Only added java 11, as Quarkus does not need java 8 anymore
* Create container images using that version to the native-image, tooling, and s2i native images
* Remove support for GraalVM 20.1.0 to the tooling image.
