### PR TITLE
Adds freetype library as per issue 112

### DIFF
--- a/modules/graalvm/20.2.0-java11/module.yaml
+++ b/modules/graalvm/20.2.0-java11/module.yaml
@@ -25,5 +25,9 @@ artifacts:
   url: *url
   md5: 17669cb10b439c0522b4d56a6b277e85
 
+packages:
+  install:
+  - fontconfig
+
 execute:
 - script: configure

--- a/modules/graalvm/20.2.0-java8/module.yaml
+++ b/modules/graalvm/20.2.0-java8/module.yaml
@@ -26,5 +26,9 @@ artifacts:
   url: *url
   md5: 1bde5d9638c13c5b50e7628eb045b6f7
 
+packages:
+  install:
+  - fontconfig
+
 execute:
 - script: configure

--- a/modules/graalvm/20.3.0-java11/module.yaml
+++ b/modules/graalvm/20.3.0-java11/module.yaml
@@ -25,5 +25,9 @@ artifacts:
   url: *url
   md5: 7bdd85e00c1e80530d711c8a2e61a153
 
+packages:
+  install:
+  - fontconfig
+
 execute:
 - script: configure

--- a/modules/mandrel/20.1.0.3.Final-java11/module.yaml
+++ b/modules/mandrel/20.1.0.3.Final-java11/module.yaml
@@ -21,5 +21,9 @@ artifacts:
   url: *url
   md5: b7081dd56eb80d86f1024dc589b92c39
 
+packages:
+  install:
+  - fontconfig
+
 execute:
 - script: configure

--- a/modules/mandrel/20.2.0.0.Final-java11/module.yaml
+++ b/modules/mandrel/20.2.0.0.Final-java11/module.yaml
@@ -21,5 +21,9 @@ artifacts:
   url: *url
   md5: 9d4a2990cd8d974bcd22846a3b96135d
 
+packages:
+  install:
+  - fontconfig
+
 execute:
 - script: configure

--- a/modules/mandrel/20.3.0.0.Beta1-java11/module.yaml
+++ b/modules/mandrel/20.3.0.0.Beta1-java11/module.yaml
@@ -21,5 +21,9 @@ artifacts:
   url: *url
   md5: 0f1cda82312940d7973aaefb5fdb59df
 
+packages:
+  install:
+  - fontconfig
+
 execute:
 - script: configure


### PR DESCRIPTION
Hello,

Closes #112 

I tried the reproducer from #112 with an altered image:

```
FROM quay.io/quarkus/ubi-quarkus-mandrel:20.3.0.0.Beta1-java11
USER root
RUN mkdir /var/cache/yum/metadata -p && \
    microdnf update libdnf
RUN microdnf install freetype.x86_64
```

And it works just fine:

```
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] Checking image status karm/ubi-quarkus-mandrel:20.3.0.0.Beta1-java11
Error response from daemon: manifest for karm/ubi-quarkus-mandrel:20.3.0.0.Beta1-java11 not found: manifest unknown: manifest unknown
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] Running Quarkus native-image plugin on GraalVM Version 20.3.0.0.Beta1 (Mandrel Distribution) (Java Version 11.0.9+11)
[INFO] [io.quarkus.deployment.pkg.steps.NativeImageBuildStep] docker run -v /home/karm/workspaceRH/rsvoboda-playground/jfreesvg/jfreesvg-quarkus/target/jfreesvg-quarkus-1.0-SNAPSHOT-native-image-source-jar:/project:z --env LANG=C --user 1000:1000 --rm karm/ubi-quarkus-mandrel:20.3.0.0.Beta1-java11 -J-Djava.util.logging.manager=org.jboss.logmanager.LogManager -J-Dsun.nio.ch.maxUpdateArraySize=100 -J-Dvertx.logger-delegate-factory-class-name=io.quarkus.vertx.core.runtime.VertxLogDelegateFactory -J-Dvertx.disableDnsResolver=true -J-Dio.netty.leakDetection.level=DISABLED -J-Dio.netty.allocator.maxOrder=1 -J-Duser.language=en -J-Dfile.encoding=UTF-8 --initialize-at-build-time= -H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy\$BySpaceAndTime -H:+JNI -jar jfreesvg-quarkus-1.0-SNAPSHOT-runner.jar -H:FallbackThreshold=0 -H:+ReportExceptionStackTraces -J-Xmx4g -H:-AddAllCharsets -H:EnableURLProtocols=http -H:-UseServiceLoaderFeature -H:+StackTrace jfreesvg-quarkus-1.0-SNAPSHOT-runner
[jfreesvg-quarkus-1.0-SNAPSHOT-runner:58]    classlist:   1,502.69 ms,  1.19 GB
[jfreesvg-quarkus-1.0-SNAPSHOT-runner:58]        (cap):     483.13 ms,  1.19 GB
[jfreesvg-quarkus-1.0-SNAPSHOT-runner:58]        setup:   1,815.41 ms,  1.19 GB
09:25:56,319 INFO  [org.jbo.threads] JBoss Threads version 3.1.1.Final
[jfreesvg-quarkus-1.0-SNAPSHOT-runner:58]     (clinit):     500.45 ms,  1.89 GB
[jfreesvg-quarkus-1.0-SNAPSHOT-runner:58]   (typeflow):   9,825.37 ms,  1.89 GB
[jfreesvg-quarkus-1.0-SNAPSHOT-runner:58]    (objects):  11,662.29 ms,  1.89 GB
[jfreesvg-quarkus-1.0-SNAPSHOT-runner:58]   (features):     507.47 ms,  1.89 GB
[jfreesvg-quarkus-1.0-SNAPSHOT-runner:58]     analysis:  23,250.48 ms,  1.89 GB
[jfreesvg-quarkus-1.0-SNAPSHOT-runner:58]     universe:   1,243.29 ms,  1.89 GB
[jfreesvg-quarkus-1.0-SNAPSHOT-runner:58]      (parse):   3,132.31 ms,  1.89 GB
[jfreesvg-quarkus-1.0-SNAPSHOT-runner:58]     (inline):   7,588.94 ms,  2.83 GB
[jfreesvg-quarkus-1.0-SNAPSHOT-runner:58]    (compile):  16,142.24 ms,  2.93 GB
[jfreesvg-quarkus-1.0-SNAPSHOT-runner:58]      compile:  28,477.03 ms,  2.93 GB
[jfreesvg-quarkus-1.0-SNAPSHOT-runner:58]        image:   4,115.87 ms,  2.93 GB
[jfreesvg-quarkus-1.0-SNAPSHOT-runner:58]        write:     472.56 ms,  2.93 GB
[jfreesvg-quarkus-1.0-SNAPSHOT-runner:58]      [total]:  61,062.38 ms,  2.93 GB
[INFO] [io.quarkus.deployment.QuarkusAugmentor] Quarkus augmentation completed in 67209ms
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:13 min
[INFO] Finished at: 2020-11-20T10:26:44+01:00
[INFO] ------------------------------------------------------------------------
```

I checked older images and they all have the same problem. I added the dependency for them too.

Thoughts? Ideas? @zakkak @jerboaa 
