### PR TITLE
Allow custom mvn build arguments

### DIFF
--- a/modules/quarkus-native-s2i-scripts/s2i/assemble
+++ b/modules/quarkus-native-s2i-scripts/s2i/assemble
@@ -34,7 +34,8 @@ else
   BUILD_DIR=target
   mvn package -Pnative -e -B \
     -DskipTests -Dmaven.javadoc.skip=true -Dmaven.site.skip=true -Dmaven.source.skip=true \
-    -Djacoco.skip=true -Dcheckstyle.skip=true -Dfindbugs.skip=true -Dpmd.skip=true -Dfabric8.skip=true
+    -Djacoco.skip=true -Dcheckstyle.skip=true -Dfindbugs.skip=true -Dpmd.skip=true \
+    -Dfabric8.skip=true ${MVN_ADDITIONAL_ARGS}
   
 fi  
 


### PR DESCRIPTION
This changes allows users to inject custom mvn arguments.
An example use-case is to provide a custom settings.xml file to use a private maven repository/proxy.