### PR TITLE
Change ownership of the project volume mount directory to the quarkus user

### DIFF
--- a/modules/add-project-dir/configure
+++ b/modules/add-project-dir/configure
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+mkdir /project
+chown quarkus:quarkus /project

--- a/modules/add-project-dir/module.yaml
+++ b/modules/add-project-dir/module.yaml
@@ -1,0 +1,7 @@
+schema_version: 1
+version: 1.0.0
+
+name: add-project-dir
+execute:
+  - script: configure
+

--- a/quarkus-mandrel.yaml
+++ b/quarkus-mandrel.yaml
@@ -26,6 +26,7 @@ modules:
   - name: glibc-langpack-en
   - name: encoding
   - name: add-quarkus-user
+  - name: add-project-dir
   - name: mandrel
     version: "_version_"
 envs:

--- a/quarkus-native-image.yaml
+++ b/quarkus-native-image.yaml
@@ -26,6 +26,7 @@ modules:
   - name: glibc-langpack-en
   - name: encoding
   - name: add-quarkus-user
+  - name: add-project-dir
   - name: graalvm
     version: "_version_"
 envs:


### PR DESCRIPTION
Container builds for a native images on a remote docker host are currently not possible (https://github.com/quarkusio/quarkus/issues/1610). The issue is that the native build step mounts a volume to the build container containing the sources for the native image build and to which the final native image is written back to the host. However, volume mounts are not available for remote docker daemons. Still, using remote docker daemons is a pretty common scenario.

I outlined a solution to this problem in a comment on the above mentioned issue https://github.com/quarkusio/quarkus/issues/1610#issuecomment-674521423, which is to copy the build sources into the container as well as copy the final native image out of the container back to the host, instead of using the volume mount. PR https://github.com/quarkusio/quarkus/pull/14635 implements this strategy, which used to work with the build images provided on quay.io some time ago (late August, I think), but does not work with the newest images anymore. It seems to be a permission issue with the `/project` mount point. It is created with the root user when building the docker image, but written to using the quarkus user (uid 1001) when building the native image, which fails. The native image builds only work, when an actual directory on the host is mounted as a volume using the z-flag. The z-flag unfortunately does not work for anonymous or named volumes.

The solution provided in this PR is to explicitly create the `/project` folder during the docker image build and let it be owned by the `quarkus` user (created in the `add-quarkus-user` module) before the volume is created on it.