### PR TITLE
Add GraalVM CE 20.3.1.2 and 21.0.0.2

### DIFF
--- a/.github/native-images.yaml
+++ b/.github/native-images.yaml
@@ -3,14 +3,13 @@ imageName: quay.io/quarkus/ubi-quarkus-native-image
 buildScript: .github/build-native-images.sh
 versions:
   - 20.2.0-java11
-  - 20.3.0-java11
-  - 20.3.1-java11
-  - 21.0.0-java11
+  - 20.3.1.2-java11
+  - 21.0.0.2-java11
 tags:
   - id: 20.2-java11
     target: 20.2.0-java11
   - id: 20.3-java11
-    target: 20.3.1-java11    
+    target: 20.3.1.2-java11    
   - id: 21.0-java11
-    target: 21.0.0-java11    
+    target: 21.0.0.2-java11    
 versionCheck: true

--- a/.github/s2i-native-images.yaml
+++ b/.github/s2i-native-images.yaml
@@ -3,14 +3,13 @@ imageName: quay.io/quarkus/ubi-quarkus-native-s2i
 buildScript: .github/build-s2i-native-images.sh
 versions:
   - 20.2.0-java11
-  - 20.3.0-java11
-  - 20.3.1-java11
-  - 21.0.0-java11
+  - 20.3.1.2-java11
+  - 21.0.0.2-java11
 tags:
   - id: 20.2-java11
     target: 20.2.0-java11
   - id: 20.3-java11
-    target: 20.3.1-java11    
+    target: 20.3.1.2-java11    
   - id: 21.0-java11
-    target: 21.0.0-java11    
+    target: 21.0.0.2-java11    
 versionCheck: false

--- a/.github/tooling-images.yaml
+++ b/.github/tooling-images.yaml
@@ -3,13 +3,13 @@ imageName: quay.io/quarkus/centos-quarkus-maven
 buildScript: .github/build-tooling-images.sh
 versions:
   - 20.2.0-java11
-  - 20.3.1-java11
-  - 21.0.0-java11
+  - 20.3.1.2-java11
+  - 21.0.0.2-java11
 tags:
   - id: 20.2-java11
     target: 20.2.0-java11
   - id: 20.3-java11
-    target: 20.3.1-java11    
+    target: 20.3.1.2-java11    
   - id: 21.0-java11
-    target: 21.0.0-java11    
+    target: 21.0.0.2-java11    
 versionCheck: false

--- a/modules/graalvm/20.3.1.2-java11/configure
+++ b/modules/graalvm/20.3.1.2-java11/configure
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+SOURCES_DIR=/tmp/artifacts
+
+ls -l ${SOURCES_DIR}
+tar xzf ${SOURCES_DIR}/${FILENAME} -C /opt
+mv /opt/graalvm-ce-${GRAALVM_VERSION} /opt/graalvm
+
+echo "Installing native-image"
+/opt/graalvm/bin/gu --auto-yes install native-image

--- a/modules/graalvm/20.3.1.2-java11/module.yaml
+++ b/modules/graalvm/20.3.1.2-java11/module.yaml
@@ -1,0 +1,33 @@
+schema_version: 1
+name: graalvm
+version: &version "20.3.1.2-java11"
+
+labels:
+  - name: graalvm-archive-filename
+    value: &filename graalvm-ce-linux-amd64-20.3.1.2-java11.tar.gz
+  - name: graalvm-archive-url
+    value: &url https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.3.1.2/graalvm-ce-java11-linux-amd64-20.3.1.2.tar.gz
+  - name: graalvm-version
+    value:   &suffix java11-20.3.1.2
+
+envs:
+  - name: "JAVA_HOME"
+    value: "/opt/graalvm"
+  - name: "GRAALVM_HOME"
+    value: "/opt/graalvm"
+  - name: "GRAALVM_VERSION"
+    value: *suffix
+  - name: "FILENAME"  
+    value: *filename
+
+artifacts:
+- name: *filename
+  url: *url
+  md5: bd28011cd98ba317dffee6a6b2bc3f88
+
+packages:
+  install:
+  - fontconfig
+
+execute:
+- script: configure

--- a/modules/graalvm/21.0.0.2-java11/configure
+++ b/modules/graalvm/21.0.0.2-java11/configure
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+SOURCES_DIR=/tmp/artifacts
+
+ls -l ${SOURCES_DIR}
+tar xzf ${SOURCES_DIR}/${FILENAME} -C /opt
+mv /opt/graalvm-ce-${GRAALVM_VERSION} /opt/graalvm
+
+echo "Installing native-image"
+/opt/graalvm/bin/gu --auto-yes install native-image

--- a/modules/graalvm/21.0.0.2-java11/module.yaml
+++ b/modules/graalvm/21.0.0.2-java11/module.yaml
@@ -1,0 +1,33 @@
+schema_version: 1
+name: graalvm
+version: &version "21.0.0.2-java11"
+
+labels:
+  - name: graalvm-archive-filename
+    value: &filename graalvm-ce-linux-amd64-21.0.0.2-java11.tar.gz
+  - name: graalvm-archive-url
+    value: &url https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.0.0.2/graalvm-ce-java11-linux-amd64-21.0.0.2.tar.gz
+  - name: graalvm-version
+    value:   &suffix java11-21.0.0.2
+
+envs:
+  - name: "JAVA_HOME"
+    value: "/opt/graalvm"
+  - name: "GRAALVM_HOME"
+    value: "/opt/graalvm"
+  - name: "GRAALVM_VERSION"
+    value: *suffix
+  - name: "FILENAME"  
+    value: *filename
+
+artifacts:
+- name: *filename
+  url: *url
+  md5: 85752b644030bcf2d31f5f1cd1cf8c83
+
+packages:
+  install:
+  - fontconfig
+
+execute:
+- script: configure


### PR DESCRIPTION


- add the modules for GraalVM CE 20.3.1.2 and 21.0.0.2
- update tags to target these versions

Fix https://github.com/quarkusio/quarkus-images/issues/135.
