### PR TITLE
Closes #60

### DIFF
--- a/modules/quarkus-native-s2i-scripts/s2i/assemble
+++ b/modules/quarkus-native-s2i-scripts/s2i/assemble
@@ -31,7 +31,11 @@ fi
   mkdir -p build/libs
   gradle build -Dquarkus.package.type=native
 else
-  BUILD_DIR=target
+  if [ -z "$ARTIFACT_DIR" ]; then
+    BUILD_DIR=target
+  else
+    BUILD_DIR=$ARTIFACT_DIR
+  fi
   mvn package -Pnative -e -B \
     -DskipTests -Dmaven.javadoc.skip=true -Dmaven.site.skip=true -Dmaven.source.skip=true \
     -Djacoco.skip=true -Dcheckstyle.skip=true -Dfindbugs.skip=true -Dpmd.skip=true \


### PR DESCRIPTION
In the assembly script of native S2I Quarkus image I've added the possibility to specify the directory where maven stores the outcome of the "package" process.
This behavior has been designed along the lines of the registry.access.redhat.com/ubi8/openjdk-11~https image, which I've successfully used to compile the same multi-module project (https://github.com/qiot-project/qiot-datahub-collector) in standard jvm mode.