### PR TITLE
Skip s2i tests until further investigation

### DIFF
--- a/.github/build-s2i-native-images.sh
+++ b/.github/build-s2i-native-images.sh
@@ -20,11 +20,11 @@ cekit --descriptor ${IMAGE} build \
     --overrides "${OVERRIDES}" \
     ${BUILD_ENGINE} --tag="${PREFIX_NAME}:${VERSION}"
 
-echo "Verifying ${PREFIX_NAME}:${VERSION}"
-export CTF_WAIT_TIME=120
-cekit test \
-   --image ${PREFIX_NAME}:${VERSION} \
-   --overrides-file ${IMAGE} \
-   --overrides "${OVERRIDES}" \
-    behave \
-   --steps-url https://github.com/cescoffier/behave-test-steps
+# echo "Verifying ${PREFIX_NAME}:${VERSION}"
+# export CTF_WAIT_TIME=120
+# cekit test \
+#    --image ${PREFIX_NAME}:${VERSION} \
+#    --overrides-file ${IMAGE} \
+#    --overrides "${OVERRIDES}" \
+#     behave \
+#    --steps-url https://github.com/cescoffier/behave-test-steps


### PR DESCRIPTION
Disable s2i tests for now as it breaks the main build.

We would need to allow filtering the version on which the tests can be executed. The problem is that the latest quarkus version (1.12) prevents the usage of GraalVM <= 21.0.