### PR TITLE
Rename QUARKUS_HOME to APP_HOME to avoid configuration warning

### DIFF
--- a/modules/add-quarkus-user/add-user
+++ b/modules/add-quarkus-user/add-user
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-groupadd -r quarkus -g 1001 && useradd -u 1001 -r -g 1001 -m -d ${QUARKUS_HOME} -s /sbin/nologin -c "Quarkus user" quarkus
+groupadd -r quarkus -g 1001 && useradd -u 1001 -r -g 1001 -m -d ${APP_HOME} -s /sbin/nologin -c "Quarkus user" quarkus

--- a/modules/add-quarkus-user/module.yaml
+++ b/modules/add-quarkus-user/module.yaml
@@ -6,5 +6,5 @@ execute:
   - script: add-user
 
 envs:
-  - name: "QUARKUS_HOME"
+  - name: "APP_HOME"
     value: "/home/quarkus"

--- a/modules/maven-config/configure
+++ b/modules/maven-config/configure
@@ -4,8 +4,8 @@ set -e
 SOURCES_DIR=/tmp/artifacts
 SCRIPT_DIR=$(dirname $0)
 
-mkdir -p ${QUARKUS_HOME}/.m2/repository
-cp -v ${SCRIPT_DIR}/maven/* ${QUARKUS_HOME}/.m2
-cp -v ${SCRIPT_DIR}/added/* ${QUARKUS_HOME}/.m2
+mkdir -p ${APP_HOME}/.m2/repository
+cp -v ${SCRIPT_DIR}/maven/* ${APP_HOME}/.m2
+cp -v ${SCRIPT_DIR}/added/* ${APP_HOME}/.m2
 
-chown -R 1001:0 ${QUARKUS_HOME}
+chown -R 1001:0 ${APP_HOME}

--- a/modules/quarkus-maven-scripts/added/entrypoint-run.sh
+++ b/modules/quarkus-maven-scripts/added/entrypoint-run.sh
@@ -7,9 +7,9 @@ set -e
 # supported values, please refer the module.yaml
 # file.
 CONFIGURE_SCRIPTS=(
-  ${QUARKUS_HOME}/.m2/configure-maven.sh
+  ${APP_HOME}/.m2/configure-maven.sh
 )
-source ${QUARKUS_HOME}/.m2/configure.sh
+source ${APP_HOME}/.m2/configure.sh
 #############################################
 
 exec "$@"

--- a/modules/quarkus-native-binary-s2i-scripts/s2i/assemble
+++ b/modules/quarkus-native-binary-s2i-scripts/s2i/assemble
@@ -15,12 +15,12 @@ echo "Assemblying"
 
 if [ "$(ls ${SRC_DIR}/*-runner | wc -l)" -eq "1" ]; then
   app_path=$(ls ${SRC_DIR}/*-runner)
-  cp -v ${app_path} ${QUARKUS_HOME}/application
-  chmod +x ${QUARKUS_HOME}/application
+  cp -v ${app_path} ${APP_HOME}/application
+  chmod +x ${APP_HOME}/application
 else
   >&2 echo "Could not locate a native image. Have you build a native image using mvn -Pnative before?"
   exit 1
 fi
 
-chmod +rx ${QUARKUS_HOME}
-chmod +x ${QUARKUS_HOME}/application
+chmod +rx ${APP_HOME}
+chmod +x ${APP_HOME}/application

--- a/modules/quarkus-native-binary-s2i-scripts/s2i/run
+++ b/modules/quarkus-native-binary-s2i-scripts/s2i/run
@@ -6,4 +6,4 @@ else
   echo "Using custom Java opts from environment QUARKUS_OPTS=${QUARKUS_OPTS}"
 fi
 
-exec ${QUARKUS_HOME}/application ${QUARKUS_OPTS} -Dquarkus.http.host=0.0.0.0
+exec ${APP_HOME}/application ${QUARKUS_OPTS} -Dquarkus.http.host=0.0.0.0

--- a/modules/quarkus-native-s2i-scripts/s2i/assemble
+++ b/modules/quarkus-native-s2i-scripts/s2i/assemble
@@ -11,9 +11,9 @@ set -ex
 # supported values, please refer the module.yaml
 # file.
 CONFIGURE_SCRIPTS=(
-  ${QUARKUS_HOME}/.m2/configure-maven.sh
+  ${APP_HOME}/.m2/configure-maven.sh
 )
-source ${QUARKUS_HOME}/.m2/configure.sh
+source ${APP_HOME}/.m2/configure.sh
 #############################################
 
 SRC_DIR=${SRC_DIR:-'/tmp/src/'}
@@ -43,6 +43,6 @@ else
   
 fi  
 
-cp -v ${BUILD_DIR}/*-runner ${QUARKUS_HOME}/application
-chmod +x ${QUARKUS_HOME}
-chmod +x ${QUARKUS_HOME}/application
+cp -v ${BUILD_DIR}/*-runner ${APP_HOME}/application
+chmod +x ${APP_HOME}
+chmod +x ${APP_HOME}/application

--- a/modules/quarkus-native-s2i-scripts/s2i/run
+++ b/modules/quarkus-native-s2i-scripts/s2i/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec ${QUARKUS_HOME}/application -Dquarkus.http.host=0.0.0.0
+exec ${APP_HOME}/application -Dquarkus.http.host=0.0.0.0

--- a/quarkus-native-binary-s2i.yaml
+++ b/quarkus-native-binary-s2i.yaml
@@ -42,6 +42,6 @@ envs:
 
 run:
   user: 1001
-  workdir: "${QUARKUS_HOME}"
+  workdir: "${APP_HOME}"
   cmd:
   - "/usr/libexec/s2i/usage"

--- a/quarkus-native-s2i.yaml
+++ b/quarkus-native-s2i.yaml
@@ -50,7 +50,7 @@ envs:
 # used directly to. (If we were a plain s2i image we would print the usage info here.)
 run:
   user: 1001
-  workdir: "${QUARKUS_HOME}"
+  workdir: "${APP_HOME}"
   cmd:
   - "/usr/libexec/s2i/run"
 

--- a/tests/features/quarkus-user.feature
+++ b/tests/features/quarkus-user.feature
@@ -13,9 +13,9 @@ Feature: Verification of the Quarkus user module
         Given container is started with entrypoint cat /etc/passwd
         Then container log should contain quarkus:x:1001:1001:Quarkus user:/home/quarkus:/sbin/nologin
 
-    Scenario: Check QUARKUS_HOME env variable
+    Scenario: Check APP_HOME env variable
         Given container is started with entrypoint env
-        Then container log should contain QUARKUS_HOME=/home/quarkus
+        Then container log should contain APP_HOME=/home/quarkus
 
     Scenario: Check that the --version command works
         Given container is started with command --version


### PR DESCRIPTION
Unrecognized configuration key "quarkus.home" was provided; it will be ignored

I did a search and replace, hopefully, it will be enough.