### PR TITLE
Updating ubi8/ubi-minimal version

### DIFF
--- a/quarkus-mandrel.yaml
+++ b/quarkus-mandrel.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 version: "SNAPSHOT"
-from: "registry.access.redhat.com/ubi8/ubi-minimal:8.3"
+from: "registry.access.redhat.com/ubi8/ubi-minimal:8.4"
 
 
 name: "quay.io/quarkus/ubi-quarkus-mandrel"

--- a/quarkus-native-binary-s2i.yaml
+++ b/quarkus-native-binary-s2i.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 
-from: "registry.access.redhat.com/ubi8/ubi-minimal:8.3"
+from: "registry.access.redhat.com/ubi8/ubi-minimal:8.4"
 name: "quay.io/quarkus/ubi-quarkus-native-binary-s2i"
 version: "SNAPSHOT"
 

--- a/quarkus-native-image.yaml
+++ b/quarkus-native-image.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 version: "SNAPSHOT"
-from: "registry.access.redhat.com/ubi8/ubi-minimal:8.3"
+from: "registry.access.redhat.com/ubi8/ubi-minimal:8.4"
 
 
 name: "quay.io/quarkus/ubi-quarkus-native-image"

--- a/quarkus-native-s2i.yaml
+++ b/quarkus-native-s2i.yaml
@@ -1,5 +1,5 @@
 schema_version: 1
-from: "registry.access.redhat.com/ubi8/ubi-minimal:8.3"
+from: "registry.access.redhat.com/ubi8/ubi-minimal:8.4"
 name: "quay.io/quarkus/ubi-quarkus-native-s2i"
 version: "SNAPSHOT"
 


### PR DESCRIPTION
In order to remove all vulnerabilities from the images deployed to quay.io, I have updated the version of ubi8/ubi-minimal to 8.4. 

My reasoning is based on the vulnerabilities listed here https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8 and here https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8?tag=8.3&push_date=1618946153000