### PR TITLE
Upgrade to Gradle 6.9

### DIFF
--- a/modules/gradle-binary/6.9/configure
+++ b/modules/gradle-binary/6.9/configure
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+SOURCES_DIR=/tmp/artifacts
+SCRIPT_DIR=$(dirname $0)
+
+unzip ${SOURCES_DIR}/gradle.zip
+mv gradle-${GRADLE_VERSION} /usr/share/gradle
+ln -s /usr/share/gradle/bin/gradle /usr/bin/gradle

--- a/modules/gradle-binary/6.9/module.yaml
+++ b/modules/gradle-binary/6.9/module.yaml
@@ -1,0 +1,20 @@
+schema_version: 1
+name: gradle-binary
+version: "6.9"
+
+envs:
+  - name: "GRADLE_VERSION"
+    value: "6.9"
+  - name: "GRADLE_HOME"
+    value: "/usr/share/gradle"
+  - name : "GRADLE_OPTS"
+    value: "-Dorg.gradle.daemon=false"
+
+# unfortunately by now the version needs to be hardcoded.
+artifacts:
+  - name: gradle.zip
+    url: https://services.gradle.org/distributions/gradle-6.9-bin.zip
+    md5: d78733d4f31f0d738951805aa67fe7c6
+
+execute:
+  - script: configure

--- a/quarkus-native-s2i.yaml
+++ b/quarkus-native-s2i.yaml
@@ -39,7 +39,7 @@ modules:
   - name: graalvm
     version: _version_
   - name: gradle-binary  
-    version: "6.3"
+    version: "6.9"
   - name: quarkus-native-s2i-scripts
 
 envs:

--- a/quarkus-tooling.yaml
+++ b/quarkus-tooling.yaml
@@ -30,7 +30,7 @@ modules:
   - name: maven-binary
     version: "3.8.1"
   - name: gradle-binary
-    version: "6.3"
+    version: "6.9"
   - name: maven-config
   - name: graalvm
     version: "_version_"


### PR DESCRIPTION
Upgrade to Gradle version to use the same version installed in the wrapper of Quarkus.
