### PR TITLE
Remove the /project volumes for the build stage as they are not needed

### DIFF
--- a/quarkus-mandrel.yaml
+++ b/quarkus-mandrel.yaml
@@ -33,10 +33,6 @@ envs:
 - name: "PATH"
   value: "$PATH:$JAVA_HOME/bin"
 
-volumes:
-- name: "volume.project"
-  path: "/project"
-
 run:
   user: 1001
   workdir: "/project"

--- a/quarkus-native-image.yaml
+++ b/quarkus-native-image.yaml
@@ -33,10 +33,6 @@ envs:
 - name: "PATH"
   value: "$PATH:$JAVA_HOME/bin"
 
-volumes:
-- name: "volume.project"
-  path: "/project"
-
 run:
   user: 1001
   workdir: "/project"


### PR DESCRIPTION
Hi,

this PR is one part of two PRs, the other is: https://github.com/quarkusio/quarkus/pull/20379
These PRs simplify and fix the maven and gradle native multi-stage docker builds.

In the base images `ubi-quarkus-native-image` and `ubi-quarkus-mandrel` the `/project` volumes are not needed and are not in spec for docker builds https://docs.docker.com/engine/reference/builder/#notes-about-specifying-volumes

> Changing the volume from within the Dockerfile: If any build steps change the data within the volume after it has been declared, those changes will be discarded.

This worked on macos for some unknown reason but not on linux, a workaround was used, but this lead to permission problems and overall greater complexity.

This PR removes these volumes from the base images.

Regards,
Fabian