### PR TITLE
Mandrel 21.3.1.0-Final and 22.0.0.2-Final for Java 11

### DIFF
--- a/.github/mandrel-images.yaml
+++ b/.github/mandrel-images.yaml
@@ -6,13 +6,17 @@ versions:
   - 21.2.0.2-Final-java11
   - 21.3.0.0-Final-java11
   - 21.3.0.0-Final-java17
+  - 21.3.1.0-Final-java11
+  - 22.0.0.2-Final-java11
 tags:
   - id: 20.3-java11
     target: 20.3.3.0-Final-java11
   - id: 21.2-java11
     target: 21.2.0.2-Final-java11
   - id: 21.3-java11
-    target: 21.3.0.0-Final-java11
+    target: 21.3.1.0-Final-java11
   - id: 21.3-java17
     target: 21.3.0.0-Final-java17
+  - id: 22.0-java11
+    target: 22.0.0.2-Final-java11
 versionCheck: true

--- a/modules/mandrel/21.3.1.0-Final-java11/configure
+++ b/modules/mandrel/21.3.1.0-Final-java11/configure
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+SOURCES_DIR=/tmp/artifacts
+
+ls -l ${SOURCES_DIR}
+mkdir -p ${GRAALVM_HOME}
+tar xzf ${SOURCES_DIR}/${FILENAME} -C ${GRAALVM_HOME} --strip-components=1

--- a/modules/mandrel/21.3.1.0-Final-java11/module.yaml
+++ b/modules/mandrel/21.3.1.0-Final-java11/module.yaml
@@ -1,0 +1,30 @@
+schema_version: 1
+name: mandrel
+version: &version "21.3.1.0-Final-java11"
+
+labels:
+  - name: mandrel-archive-filename
+    value: &filename mandrel-java11-linux-amd64-21.3.1.0-Final.tar.gz
+  - name: mandrel-archive-url
+    value: &url https://github.com/graalvm/mandrel/releases/download/mandrel-21.3.1.0-Final/mandrel-java11-linux-amd64-21.3.1.0-Final.tar.gz
+
+envs:
+  - name: "JAVA_HOME"
+    value: "/opt/mandrel"
+  - name: "GRAALVM_HOME"
+    value: "/opt/mandrel"
+  - name: "FILENAME"
+    value: *filename
+
+artifacts:
+- name: *filename
+  url: *url
+  sha256: 2fb3f386c0df7fe31970c333bb89c215161e8499718996632ac50398ed247a48
+
+packages:
+  install:
+  - fontconfig
+  - freetype-devel
+
+execute:
+- script: configure

--- a/modules/mandrel/22.0.0.2-Final-java11/configure
+++ b/modules/mandrel/22.0.0.2-Final-java11/configure
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+SOURCES_DIR=/tmp/artifacts
+
+ls -l ${SOURCES_DIR}
+mkdir -p ${GRAALVM_HOME}
+tar xzf ${SOURCES_DIR}/${FILENAME} -C ${GRAALVM_HOME} --strip-components=1

--- a/modules/mandrel/22.0.0.2-Final-java11/module.yaml
+++ b/modules/mandrel/22.0.0.2-Final-java11/module.yaml
@@ -1,0 +1,30 @@
+schema_version: 1
+name: mandrel
+version: &version "22.0.0.2-Final-java11"
+
+labels:
+  - name: mandrel-archive-filename
+    value: &filename mandrel-java11-linux-amd64-22.0.0.2-Final.tar.gz
+  - name: mandrel-archive-url
+    value: &url https://github.com/graalvm/mandrel/releases/download/mandrel-22.0.0.2-Final/mandrel-java11-linux-amd64-22.0.0.2-Final.tar.gz
+
+envs:
+  - name: "JAVA_HOME"
+    value: "/opt/mandrel"
+  - name: "GRAALVM_HOME"
+    value: "/opt/mandrel"
+  - name: "FILENAME"
+    value: *filename
+
+artifacts:
+- name: *filename
+  url: *url
+  sha256: 57d8cc4777e513db492d8bf51521201bad0600ef95bf0afd687bf44f9bda8a87
+
+packages:
+  install:
+  - fontconfig
+  - freetype-devel
+
+execute:
+- script: configure


### PR DESCRIPTION
As agreed with @jerboaa and @zakkak, we are going ahead with Java 11 based release while Java 17 one is still in the making.