### PR TITLE
Fix glibc version in tooling image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ buildNumber.properties
 
 *~s2i
 s2i
+
+.idea
+*.iml

--- a/modules/tooling-packages/module.yaml
+++ b/modules/tooling-packages/module.yaml
@@ -1,0 +1,14 @@
+schema_version: 1
+version: 1.0.0
+
+name: tooling-packages
+packages:
+  install:
+    - tar
+    - gzip
+    - gcc
+    - glibc-devel-2.28-196.el8
+    - zlib-devel
+    - shadow-utils
+    - unzip
+    - gcc-c++

--- a/quarkus-tooling.yaml
+++ b/quarkus-tooling.yaml
@@ -22,7 +22,7 @@ modules:
   repositories:
   - path: modules
   install:
-  - name: common-packages
+  - name: tooling-packages
   - name: glibc-langpack-en
   - name: encoding
   - name: add-quarkus-user


### PR DESCRIPTION
Closes #189

Fix the glibc version in tooling image to avoid issues with the very latest glibc update.