### PR TITLE
Mandrel 21.3.2.0 and 22.1.0.0

### DIFF
--- a/.github/mandrel-images.yaml
+++ b/.github/mandrel-images.yaml
@@ -12,18 +12,20 @@ versions:
   - 22.0.0.2-Final-java17
   - 21.3.1.1-Final-java17
   - 21.3.1.1-Final-java11
+  - 21.3.2.0-Final-java11
+  - 21.3.2.0-Final-java17
+  - 22.1.0.0-Final-java11
+  - 22.1.0.0-Final-java17
 
 tags:
   - id: 20.3-java11
     target: 20.3.3.0-Final-java11
-  - id: 21.2-java11
-    target: 21.2.0.2-Final-java11
   - id: 21.3-java11
-    target: 21.3.1.1-Final-java11
+    target: 21.3.2.0-Final-java11
   - id: 21.3-java17
-    target: 21.3.1.1-Final-java17
-  - id: 22.0-java11
-    target: 22.0.0.2-Final-java11
-  - id: 22.0-java17
-    target: 22.0.0.2-Final-java17
+    target: 21.3.2.0-Final-java17
+  - id: 22.1-java11
+    target: 22.1.0.0-Final-java11
+  - id: 22.1-java17
+    target: 22.1.0.0-Final-java17
 versionCheck: true

--- a/modules/mandrel/21.3.2.0-Final-java11/configure
+++ b/modules/mandrel/21.3.2.0-Final-java11/configure
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+SOURCES_DIR=/tmp/artifacts
+
+ls -l ${SOURCES_DIR}
+mkdir -p ${GRAALVM_HOME}
+tar xzf ${SOURCES_DIR}/${FILENAME} -C ${GRAALVM_HOME} --strip-components=1

--- a/modules/mandrel/21.3.2.0-Final-java11/module.yaml
+++ b/modules/mandrel/21.3.2.0-Final-java11/module.yaml
@@ -1,0 +1,30 @@
+schema_version: 1
+name: mandrel
+version: &version "21.3.2.0-Final-java11"
+
+labels:
+  - name: mandrel-archive-filename
+    value: &filename mandrel-java11-linux-amd64-21.3.2.0-Final.tar.gz
+  - name: mandrel-archive-url
+    value: &url https://github.com/graalvm/mandrel/releases/download/mandrel-21.3.2.0-Final/mandrel-java11-linux-amd64-21.3.2.0-Final.tar.gz
+
+envs:
+  - name: "JAVA_HOME"
+    value: "/opt/mandrel"
+  - name: "GRAALVM_HOME"
+    value: "/opt/mandrel"
+  - name: "FILENAME"
+    value: *filename
+
+artifacts:
+- name: *filename
+  url: *url
+  sha256: 2d6d96b8b22ce7ec92ed00ba2dc69909c691738a16111c9c3b284b8aed7657ea
+
+packages:
+  install:
+  - fontconfig
+  - freetype-devel
+
+execute:
+- script: configure

--- a/modules/mandrel/21.3.2.0-Final-java17/configure
+++ b/modules/mandrel/21.3.2.0-Final-java17/configure
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+SOURCES_DIR=/tmp/artifacts
+
+ls -l ${SOURCES_DIR}
+mkdir -p ${GRAALVM_HOME}
+tar xzf ${SOURCES_DIR}/${FILENAME} -C ${GRAALVM_HOME} --strip-components=1

--- a/modules/mandrel/21.3.2.0-Final-java17/module.yaml
+++ b/modules/mandrel/21.3.2.0-Final-java17/module.yaml
@@ -1,0 +1,30 @@
+schema_version: 1
+name: mandrel
+version: &version "21.3.2.0-Final-java17"
+
+labels:
+  - name: mandrel-archive-filename
+    value: &filename mandrel-java17-linux-amd64-21.3.2.0-Final.tar.gz
+  - name: mandrel-archive-url
+    value: &url https://github.com/graalvm/mandrel/releases/download/mandrel-21.3.2.0-Final/mandrel-java17-linux-amd64-21.3.2.0-Final.tar.gz
+
+envs:
+  - name: "JAVA_HOME"
+    value: "/opt/mandrel"
+  - name: "GRAALVM_HOME"
+    value: "/opt/mandrel"
+  - name: "FILENAME"
+    value: *filename
+
+artifacts:
+- name: *filename
+  url: *url
+  sha256: e23c0b09326ccc6836d0218b74c5382b3b5c79c80cd724ecdde34212d91fc0fc
+
+packages:
+  install:
+  - fontconfig
+  - freetype-devel
+
+execute:
+- script: configure

--- a/modules/mandrel/22.1.0.0-Final-java11/configure
+++ b/modules/mandrel/22.1.0.0-Final-java11/configure
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+SOURCES_DIR=/tmp/artifacts
+
+ls -l ${SOURCES_DIR}
+mkdir -p ${GRAALVM_HOME}
+tar xzf ${SOURCES_DIR}/${FILENAME} -C ${GRAALVM_HOME} --strip-components=1

--- a/modules/mandrel/22.1.0.0-Final-java11/module.yaml
+++ b/modules/mandrel/22.1.0.0-Final-java11/module.yaml
@@ -1,0 +1,30 @@
+schema_version: 1
+name: mandrel
+version: &version "22.1.0.0-Final-java11"
+
+labels:
+  - name: mandrel-archive-filename
+    value: &filename mandrel-java11-linux-amd64-22.1.0.0-Final.tar.gz
+  - name: mandrel-archive-url
+    value: &url https://github.com/graalvm/mandrel/releases/download/mandrel-22.1.0.0-Final/mandrel-java11-linux-amd64-22.1.0.0-Final.tar.gz
+
+envs:
+  - name: "JAVA_HOME"
+    value: "/opt/mandrel"
+  - name: "GRAALVM_HOME"
+    value: "/opt/mandrel"
+  - name: "FILENAME"
+    value: *filename
+
+artifacts:
+- name: *filename
+  url: *url
+  sha256: 25bc444053bf5d162b932bfb68ffba40612ad0685f19edc68869fdcc0c38b0a8
+
+packages:
+  install:
+  - fontconfig
+  - freetype-devel
+
+execute:
+- script: configure

--- a/modules/mandrel/22.1.0.0-Final-java17/configure
+++ b/modules/mandrel/22.1.0.0-Final-java17/configure
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+SOURCES_DIR=/tmp/artifacts
+
+ls -l ${SOURCES_DIR}
+mkdir -p ${GRAALVM_HOME}
+tar xzf ${SOURCES_DIR}/${FILENAME} -C ${GRAALVM_HOME} --strip-components=1

--- a/modules/mandrel/22.1.0.0-Final-java17/module.yaml
+++ b/modules/mandrel/22.1.0.0-Final-java17/module.yaml
@@ -1,0 +1,30 @@
+schema_version: 1
+name: mandrel
+version: &version "22.1.0.0-Final-java17"
+
+labels:
+  - name: mandrel-archive-filename
+    value: &filename mandrel-java17-linux-amd64-22.1.0.0-Final.tar.gz
+  - name: mandrel-archive-url
+    value: &url https://github.com/graalvm/mandrel/releases/download/mandrel-22.1.0.0-Final/mandrel-java17-linux-amd64-22.1.0.0-Final.tar.gz
+
+envs:
+  - name: "JAVA_HOME"
+    value: "/opt/mandrel"
+  - name: "GRAALVM_HOME"
+    value: "/opt/mandrel"
+  - name: "FILENAME"
+    value: *filename
+
+artifacts:
+- name: *filename
+  url: *url
+  sha256: b40bf617fd957fcb7fe61acc2621d0a84931822498b83b968f704b47e1e2edaf
+
+packages:
+  install:
+  - fontconfig
+  - freetype-devel
+
+execute:
+- script: configure


### PR DESCRIPTION
Release:
*	21.3.2.0-Final-java11/
*	21.3.2.0-Final-java17/
*	22.1.0.0-Final-java11/
*	22.1.0.0-Final-java17/

+ reshuffling tags to reflect the latest.
