### PR TITLE
Fix the configuration of the mandrel.yaml file path

### DIFF
--- a/quarkus-mandrel-builder-image/pom.xml
+++ b/quarkus-mandrel-builder-image/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <jbang.script>${project.build.sourceDirectory}/io/quarkus/images/Build.java</jbang.script>
+        <images.file>${project.basedir}/mandrel.yaml</images.file>
     </properties>
 
     <build>
@@ -34,7 +35,7 @@
                         <argument>--dockerfile-dir=${project.basedir}/target/docker</argument>
                         <argument>--ubi-minimal=${ubi-min.base}</argument>
                         <argument>--out=quay.io/quarkus/ubi-quarkus-mandrel-builder-image</argument>
-                        <argument>--in=${project.basedir}/mandrel.yaml</argument>
+                        <argument>--in=${images.file}</argument>
                         <argument>--dry-run=${jdock.dry-run}</argument>
                     </args>
                 </configuration>


### PR DESCRIPTION
Fix a bug in the `pom.xml` of the mandrel builder maven project, which would not override the image file. 