### PR TITLE
Reduce builder image size

### DIFF
--- a/jdock/src/main/java/io/quarkus/images/modules/GraalVMModule.java
+++ b/jdock/src/main/java/io/quarkus/images/modules/GraalVMModule.java
@@ -19,13 +19,13 @@ public class GraalVMModule extends AbstractModule {
     private final boolean isLegacyGraalVm;
 
     private static final String TEMPLATE = """
-            --mount=type=bind,source=%s,target=/tmp/%s \\
+            --mount=type=bind,source=%s,target=%s \\
             tar xzf %s -C /opt \\
               && mv /opt/graalvm-ce-*-%s* /opt/graalvm \\
               && %s/bin/gu --auto-yes install native-image""";
 
     private static final String NEW_TEMPLATE = """
-            --mount=type=bind,source=%s,target=/tmp/%s \\
+            --mount=type=bind,source=%s,target=%s \\
             tar xzf %s -C /opt \\
               && mv /opt/graalvm-community-openjdk-%s* /opt/graalvm""";
     private final String graalvmVersion;
@@ -71,13 +71,13 @@ public class GraalVMModule extends AbstractModule {
         String script;
         if (isLegacyGraalVm) {
             script = TEMPLATE.formatted(
-                    artifact.path, artifact.name, // mount bind
+                    artifact.path, "/tmp/" + artifact.name, // mount bind
                     "/tmp/" + artifact.name, // tar
                     graalvmVersion, // mv
                     GRAALVM_HOME); // gu
         } else {
             script = NEW_TEMPLATE.formatted(
-                    artifact.path, artifact.name, // mount bind
+                    artifact.path, "/tmp/" + artifact.name, // mount bind
                     "/tmp/" + artifact.name, // tar
                     graalvmVersion);
         }

--- a/jdock/src/main/java/io/quarkus/images/modules/MandrelModule.java
+++ b/jdock/src/main/java/io/quarkus/images/modules/MandrelModule.java
@@ -14,9 +14,9 @@ public class MandrelModule extends AbstractModule {
     private final String filename;
 
     private static final String TEMPLATE = """
+            --mount=type=bind,source=%s,target=/tmp/%s \\
             mkdir -p %s \\
-                && tar xzf %s -C %s --strip-components=1 \\
-                && rm -Rf %s""";
+                && tar xzf %s -C %s --strip-components=1""";
 
     public MandrelModule(String version, String arch, String javaVersion, String sha) {
         super("mandrel",
@@ -39,11 +39,14 @@ public class MandrelModule extends AbstractModule {
     public List<Command> commands(BuildContext bc) {
         Artifact artifact = bc.addArtifact(new Artifact(filename, url, sha));
         String script = TEMPLATE.formatted(
-                MANDREL_HOME, "/tmp/" + artifact.name, MANDREL_HOME, "/tmp/" + artifact.name);
+                artifact.path, artifact.name, // mount bind
+                MANDREL_HOME, // mkdir
+                "/tmp/" + artifact.name, MANDREL_HOME, //tar
+                "/tmp/" + artifact.name); //rm
+
         return List.of(
                 new EnvCommand("JAVA_HOME", MANDREL_HOME, "GRAALVM_HOME", MANDREL_HOME),
                 new MicrodnfCommand("fontconfig", "freetype-devel"),
-                new CopyCommand(artifact, "/tmp/" + artifact.name),
                 new RunCommand(script));
     }
 }

--- a/jdock/src/main/java/io/quarkus/images/modules/MandrelModule.java
+++ b/jdock/src/main/java/io/quarkus/images/modules/MandrelModule.java
@@ -14,7 +14,7 @@ public class MandrelModule extends AbstractModule {
     private final String filename;
 
     private static final String TEMPLATE = """
-            --mount=type=bind,source=%s,target=/tmp/%s \\
+            --mount=type=bind,source=%s,target=%s \\
             mkdir -p %s \\
                 && tar xzf %s -C %s --strip-components=1""";
 
@@ -39,7 +39,7 @@ public class MandrelModule extends AbstractModule {
     public List<Command> commands(BuildContext bc) {
         Artifact artifact = bc.addArtifact(new Artifact(filename, url, sha));
         String script = TEMPLATE.formatted(
-                artifact.path, artifact.name, // mount bind
+                artifact.path, "/tmp/" + artifact.name, // mount bind
                 MANDREL_HOME, // mkdir
                 "/tmp/" + artifact.name, MANDREL_HOME, //tar
                 "/tmp/" + artifact.name); //rm


### PR DESCRIPTION
Avoid persisting temporary tar.gz files in builder images by using bind type mount (#240)

~As @cescoffier [pointed out](https://github.com/quarkusio/quarkus-images/issues/240#issuecomment-1606194646), it looks like this is a compatible podman syntax but it needs to be confirmed (if someone can give it a try 🙏)~
Finally had time to setup a VM to confirm it is working with podman