### PR TITLE
GraalVM CE - July 2023 update

### DIFF
--- a/quarkus-graalvm-builder-image/graalvm-22.yaml
+++ b/quarkus-graalvm-builder-image/graalvm-22.yaml
@@ -16,42 +16,19 @@ images:
       - sha: 3025cc887bdaa088c89601b42931abc61dfd108aaad386abee8c1e08c913504d
         arch: arm64
 
-  - graalvm-version: 22.3.1
-    java-version: 11
-    variants:
-      - sha: 55547725a8be3ceb0a1da29a84cd3e958ba398ce4470ac89a8ba1bdb6d9bddb8
-        arch: amd64
-      - sha: b46a3f9c82ac70990a62282b1fbe4474e784d9ba453839a428f88e94d21f8abc
-        arch: arm64
-  - graalvm-version: 22.3.1
-    java-version: 17
-    variants:
-      - sha: 3acf4a59ae38cb0cd331a81777f6d24f8fdc6179ac25e5b198b6e08c444c9129
-        arch: amd64
-      - sha: a954fe8a4962be6ac8d0efff9ebf15108df59fad299213a31d2451bc78434818
-        arch: arm64
-  - graalvm-version: 22.3.1
-    java-version: 19
-    tag: 22.3-java19
-    variants:
-      - sha: 7cd99d805e7a8b7d4c4576802fb107fb862944e47ce5f2e4f37c0f469a70dd2f
-        arch: amd64
-      - sha: 95b0d0b1bf7e586695d8cf595df7a532b25314745397bb3d044cd00c409f6a0d
-        arch: arm64
-
-  - graalvm-version: 22.3.2
+  - graalvm-version: 22.3.3
     java-version: 11
     tag: 22.3-java11
     variants:
-      - sha: 0e638d2b7406fabc15a1079fc65431a4f33f6f754da77e4073de8433b40e7c4a
+      - sha: 959154e1248108dcd6eb279032cecdd2a6076bdebb345de9532681185231d255
         arch: amd64
-      - sha: 506c99fef656653ccbc57facb9f200303bfcc21ea29679e7391046d0990493da
+      - sha: 177d682f3455d00fa2491246e809d9c9b743187a82115ad3f578998b4935d5a1
         arch: arm64
-  - graalvm-version: 22.3.2
+  - graalvm-version: 22.3.3
     java-version: 17
     tag: 22.3-java17
     variants:
-      - sha: e5a5868c9b498643fadebfba2040e4d9a19a13ea58ec77cec8d64ab6ee691d1e
+      - sha: ebc3200057ca865f0389abceb210f2d4c77d02cf09acf5ede1631d6b70924b00
         arch: amd64
-      - sha: 5d8614c75f5496b37ba52c3ae80a5e887a03981c2d22ade187e8793562b66e84
+      - sha: 1a6bf2ea2715aa8feacc81a78c41b7f2fe6f94cdde56696f72238474f1fc2598
         arch: arm64

--- a/quarkus-graalvm-builder-image/graalvm.yaml
+++ b/quarkus-graalvm-builder-image/graalvm.yaml
@@ -1,18 +1,18 @@
 images:
-  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-17.0.7
-  - java-version: 17.0.7
+  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-17.0.8
+  - java-version: 17.0.8
     tags: jdk-17
     variants:
       - arch: amd64
-        sha: 094e5a7dcc4a903b70741d5c3c1688f83e83e2d44eb3d8d798c5d79ed902032c
+        sha: 1dffdf5c7cc5bf38558e9f093eef6a14072a6dff0be3a9906208b37b53ecc009
       - arch: arm64
-        sha: cb5bedf6244d30018856559a393029e98de48c9608eb35ec6c4937dcb7d97224
+        sha: c4f26318114d6bd125cc95ee070289afdd42c6683867adf832f2ab2819c3b685
 
-  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-20.0.1
-  - java-version: 20.0.1
+  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-20.0.2
+  - java-version: 20.0.2
     tags: jdk-20
     variants:
       - arch: amd64
-        sha: 1c965f4698a5435bb8d094c9b2a13f7079e43d9934915964a2ee15fb81b53a79
+        sha: 941a85a690e7b1c4e1fcfac321561ca46033bba3ac4882dd15d4f45edd06726c
       - arch: arm64
-        sha: ffb205a6fc0b84cbc5d38e86ce12fe01294ba1507c1a72535f63a57c57513a35
+        sha: 6022709c124191da5087d0b0c62c3246943b3d5a386717c8d1af593637217028

--- a/quarkus-native-s2i/graalvm.yaml
+++ b/quarkus-native-s2i/graalvm.yaml
@@ -1,36 +1,36 @@
 images:
-   # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-17.0.7
-  - java-version: 17.0.7
+  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-17.0.8
+  - java-version: 17.0.8
     tags: jdk-17
     variants:
       - arch: amd64
-        sha: 094e5a7dcc4a903b70741d5c3c1688f83e83e2d44eb3d8d798c5d79ed902032c
+        sha: 1dffdf5c7cc5bf38558e9f093eef6a14072a6dff0be3a9906208b37b53ecc009
       - arch: arm64
-        sha: cb5bedf6244d30018856559a393029e98de48c9608eb35ec6c4937dcb7d97224
+        sha: c4f26318114d6bd125cc95ee070289afdd42c6683867adf832f2ab2819c3b685
 
-    # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-20.0.1
-  - java-version: 20.0.1
+  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-20.0.2
+  - java-version: 20.0.2
     tags: jdk-20
     variants:
       - arch: amd64
-        sha: 1c965f4698a5435bb8d094c9b2a13f7079e43d9934915964a2ee15fb81b53a79
+        sha: 941a85a690e7b1c4e1fcfac321561ca46033bba3ac4882dd15d4f45edd06726c
       - arch: arm64
-        sha: ffb205a6fc0b84cbc5d38e86ce12fe01294ba1507c1a72535f63a57c57513a35
+        sha: 6022709c124191da5087d0b0c62c3246943b3d5a386717c8d1af593637217028
 
-  - graalvm-version: 22.3.2
+  - graalvm-version: 22.3.3
     java-version: 11
     tag: 22.3-java11
     variants:
-      - sha: 0e638d2b7406fabc15a1079fc65431a4f33f6f754da77e4073de8433b40e7c4a
+      - sha: 959154e1248108dcd6eb279032cecdd2a6076bdebb345de9532681185231d255
         arch: amd64
-      - sha: 506c99fef656653ccbc57facb9f200303bfcc21ea29679e7391046d0990493da
+      - sha: 177d682f3455d00fa2491246e809d9c9b743187a82115ad3f578998b4935d5a1
         arch: arm64
-  - graalvm-version: 22.3.2
+  - graalvm-version: 22.3.3
     java-version: 17
     tag: 22.3-java17
     variants:
-      - sha: e5a5868c9b498643fadebfba2040e4d9a19a13ea58ec77cec8d64ab6ee691d1e
+      - sha: ebc3200057ca865f0389abceb210f2d4c77d02cf09acf5ede1631d6b70924b00
         arch: amd64
-      - sha: 5d8614c75f5496b37ba52c3ae80a5e887a03981c2d22ade187e8793562b66e84
+      - sha: 1a6bf2ea2715aa8feacc81a78c41b7f2fe6f94cdde56696f72238474f1fc2598
         arch: arm64
-     
+


### PR DESCRIPTION
Update GraalVM CE images to:

- 22.3.3 (java 11 and 17)
- 23.x (java 17.0.8, 20.0.2)
