### PR TITLE
Labels in multiple lines should be separated with " \" instead of "\"

### DIFF
--- a/jdock/src/main/java/io/quarkus/images/commands/LabelCommand.java
+++ b/jdock/src/main/java/io/quarkus/images/commands/LabelCommand.java
@@ -14,7 +14,7 @@ public class LabelCommand implements Command {
                 name = s;
             } else {
                 if (builder.length() > 0) {
-                    builder.append("\\\n");
+                    builder.append(" \\\n");
                 }
                 builder.append(name).append("=\"").append(s).append("\"");
                 name = null;


### PR DESCRIPTION
When I use `s2i` tool locally with image `quay.io/quarkus/ubi-quarkus-native-binary-s2i:2.0-2024-01-28` to build a sample Quarkus native executable into a Docker image, it reports:

```
warning: Image sha256:21fabcb9c96cd2a8beb89d9d1203ffca9805e95d8986c2567717d8728247c162 does not contain a value for the io.openshift.s2i.scripts-url label
Build failed
ERROR: An error occurred: failed to install [assemble run]
ERROR: Suggested solution: set the scripts URL parameter with the location of the S2I scripts, or check if the image has the "io.openshift.s2i.scripts-url" label set
ERROR: If the problem persists consult the docs at https://github.com/openshift/source-to-image/tree/master/docs. Eventually reach us on freenode #openshift or file an issue at https://github.com/openshift/source-to-image/issues providing us with a log from your build using log output level 3.
```

The root cause is that labels in multiple lines are separated with `\` in Dockerfile, which caused the required label `"io.openshift.s2i.scripts-url` not shown up in the image. The PR is to fix the issue by adding a missing whitespace to correctly separate labels in multiple lines.

The issue impacts all images produced by Dockerfile generated with `LabelCommand.java`.

## Reproduce with the published image

Execute the following steps:

1. Pull image: `docker pull quay.io/quarkus/ubi-quarkus-native-binary-s2i:2.0-2024-01-28`
1. Retrieve labels by inspecting image: `docker inspect quay.io/quarkus/ubi-quarkus-native-binary-s2i:2.0-2024-01-28 | jq '.[0].Config.Labels'`

You should see key-value for label **io.k8s.description** as below, which contains required label `io.openshift.s2i.scripts-url`:
```
"io.k8s.description": "Quarkus.io S2I image for running native images on Red Hat UBI 8io.k8s.display-name=Quarkus.io S2I (UBI8)io.openshift.expose-services=8080:httpio.openshift.s2i.destination=/tmpio.openshift.s2i.scripts-url=image:///usr/libexec/s2iio.openshift.tags=builder,quarkus,nativemaintainer=Quarkus Team <quarkus-dev@googlegroups.com>"
```

### Expected result

The key-value for label **io.k8s.description** should be divided into the following labels:

```
"io.k8s.description": "Quarkus.io S2I image for running native images on Red Hat UBI 8",
"io.k8s.display-name": "Quarkus.io S2I (UBI8)",
"io.openshift.expose-services": "8080:http",
"io.openshift.s2i.destination": "/tmp",
"io.openshift.s2i.scripts-url": "image:///usr/libexec/s2i",
"io.openshift.tags": "builder,quarkus,native",
"maintainer": "Quarkus Team <quarkus-dev@googlegroups.com>"
```

## Reproduce with the source code

Execute the following steps:

1. Clone the project: `git clone https://github.com/quarkusio/quarkus-images.git`
1. Build the project: `cd quarkus-images && mvn install -Djdock.dry-run=true`
1. Check out generated Dockerfile: `cat quarkus-binary-s2i/target/docker/ubi-quarkus-native-binary-s2i:2.0-amd64.Dockerfile`

You should see labels in multiple lines are separated with `\`:
```
LABEL io.k8s.description="Quarkus.io S2I image for running native images on Red Hat UBI 8"\
io.k8s.display-name="Quarkus.io S2I (UBI8)"\
io.openshift.expose-services="8080:http"\
io.openshift.s2i.destination="/tmp"\
io.openshift.s2i.scripts-url="image:///usr/libexec/s2i"\
io.openshift.tags="builder,quarkus,native"\
maintainer="Quarkus Team <quarkus-dev@googlegroups.com>"
```

### Expected result

Labels in multiple lines are separated with ` \`:
```
LABEL io.k8s.description="Quarkus.io S2I image for running native images on Red Hat UBI 8" \
io.k8s.display-name="Quarkus.io S2I (UBI8)" \
io.openshift.expose-services="8080:http" \
io.openshift.s2i.destination="/tmp" \
io.openshift.s2i.scripts-url="image:///usr/libexec/s2i" \
io.openshift.tags="builder,quarkus,native" \
maintainer="Quarkus Team <quarkus-dev@googlegroups.com>"
```