### PR TITLE
Bump ubi-micro and ubi-minimal to 8.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,9 @@ To update them, edit the `pom.xml` file:
 
 ```xml
 <!-- See https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8 -->
-<ubi-min.base>registry.access.redhat.com/ubi8/ubi-minimal:8.8</ubi-min.base>
+<ubi-min.base>registry.access.redhat.com/ubi8/ubi-minimal:8.9</ubi-min.base>
 <!-- See https://catalog.redhat.com/software/containers/ubi8/ubi-micro/5ff3f50a831939b08d1b832a -->
-<ubi-micro.base>registry.access.redhat.com/ubi8-micro:8.8</ubi-micro.base>
+<ubi-micro.base>registry.access.redhat.com/ubi8-micro:8.9</ubi-micro.base>
 ```
 
 ### Pushing the image to quay

--- a/jdock/src/test/java/io/quarkus/images/Builders.java
+++ b/jdock/src/test/java/io/quarkus/images/Builders.java
@@ -5,7 +5,7 @@ import io.quarkus.images.modules.*;
 public class Builders {
 
     public static Dockerfile getMandrelDockerFile(String version, String javaVersion, String arch, String sha) {
-        Dockerfile df = Dockerfile.from("registry.access.redhat.com/ubi8/ubi-minimal:8.8");
+        Dockerfile df = Dockerfile.from("registry.access.redhat.com/ubi8/ubi-minimal:8.9");
         df
                 .installer("microdnf")
                 .user("root")
@@ -29,7 +29,7 @@ public class Builders {
     }
 
     public static Dockerfile getGraalVmDockerFile(String version, String javaVersion, String arch, String sha) {
-        Dockerfile df = Dockerfile.from("registry.access.redhat.com/ubi8/ubi-minimal:8.8");
+        Dockerfile df = Dockerfile.from("registry.access.redhat.com/ubi8/ubi-minimal:8.9");
         df
                 .installer("microdnf")
                 .user("root")

--- a/jdock/src/test/java/io/quarkus/images/DistrolessTest.java
+++ b/jdock/src/test/java/io/quarkus/images/DistrolessTest.java
@@ -28,7 +28,7 @@ public class DistrolessTest {
     void testBuildingMicroImage() {
         System.out.println(Dockerfile
                 .multistages()
-                .stage("ubi", Dockerfile.from("registry.access.redhat.com/ubi8/ubi-minimal:8.8"))
+                .stage("ubi", Dockerfile.from("registry.access.redhat.com/ubi8/ubi-minimal:8.9"))
                 .stage("scratch", Dockerfile.from("registry.access.redhat.com/ubi8/ubi-micro"))
                 .stage(Dockerfile.from("scratch")
                         .copyFromStage("ubi", "/usr/lib64/libgcc_s.so.1")

--- a/jdock/src/test/java/io/quarkus/images/MultiMicroTest.java
+++ b/jdock/src/test/java/io/quarkus/images/MultiMicroTest.java
@@ -18,7 +18,7 @@ public class MultiMicroTest {
     @Test
     void test() {
         MultiStageDockerFile micro = Dockerfile.multistages()
-                .stage("ubi", Dockerfile.from("registry.access.redhat.com/ubi8/ubi-minimal:8.8"))
+                .stage("ubi", Dockerfile.from("registry.access.redhat.com/ubi8/ubi-minimal:8.9"))
                 .stage("scratch", Dockerfile.from("registry.access.redhat.com/ubi8/ubi-micro"))
                 .stage(Dockerfile.from("scratch")
                         .copyFromStage("ubi", "/usr/lib64/libgcc_s.so.1")

--- a/jdock/src/test/java/io/quarkus/images/SimpleTest.java
+++ b/jdock/src/test/java/io/quarkus/images/SimpleTest.java
@@ -58,14 +58,14 @@ class SimpleTest {
 
     @Test
     public void testRunWithExecForm() {
-        Dockerfile df = Dockerfile.from("registry.access.redhat.com/ubi8/ubi-minimal:8.8");
+        Dockerfile df = Dockerfile.from("registry.access.redhat.com/ubi8/ubi-minimal:8.9");
         df.exec("/bin/bash", "-c", "echo hello");
         assertThat(df.build()).contains("RUN [ \"/bin/bash\", \"-c\", \"echo hello\" ]\n");
     }
 
     @Test
     public void testRunWithShellForm() {
-        Dockerfile df = Dockerfile.from("registry.access.redhat.com/ubi8/ubi-minimal:8.8");
+        Dockerfile df = Dockerfile.from("registry.access.redhat.com/ubi8/ubi-minimal:8.9");
         df.run("source $HOME/.bashrc", "echo $HOME");
         assertThat(df.build()).contains("RUN source $HOME/.bashrc \\\n && echo $HOME\n");
     }

--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,9 @@
         <maven.compiler.target>17</maven.compiler.target>
 
         <!-- See https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8 -->
-        <ubi-min.base>registry.access.redhat.com/ubi8/ubi-minimal:8.8</ubi-min.base>
+        <ubi-min.base>registry.access.redhat.com/ubi8/ubi-minimal:8.9</ubi-min.base>
         <!-- See https://catalog.redhat.com/software/containers/ubi8/ubi-micro/5ff3f50a831939b08d1b832a -->
-        <ubi-micro.base>registry.access.redhat.com/ubi8-micro:8.8</ubi-micro.base>
+        <ubi-micro.base>registry.access.redhat.com/ubi8-micro:8.9</ubi-micro.base>
 
         <jdock.dry-run>false</jdock.dry-run>
     </properties>


### PR DESCRIPTION
Bumps `ubi-micro` and `ubi-minimal` to `8.9`.
This is the [latest](https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8?architecture=amd64&image=660383f31ba64b6bd44df0a7) version. It is mentioned in Quarkus [documentation](https://quarkus.io/guides/quarkus-runtime-base-image) as well.