### PR TITLE
Bump ubi-micro and ubi-minimal to 8.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,9 @@ To update them, edit the `pom.xml` file:
 
 ```xml
 <!-- See https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8 -->
-<ubi-min.base>registry.access.redhat.com/ubi8/ubi-minimal:8.9</ubi-min.base>
-<!-- See https://catalog.redhat.com/software/containers/ubi8/ubi-micro/5ff3f50a831939b08d1b832a -->
-<ubi-micro.base>registry.access.redhat.com/ubi8-micro:8.9</ubi-micro.base>
+<ubi-min.base>registry.access.redhat.com/ubi8/ubi-minimal:8.10</ubi-min.base>
+<!-- See https://catalog.redhat.com/software/containers/ubi8-micro/601a84aadd19c7786c47c8ea -->
+<ubi-micro.base>registry.access.redhat.com/ubi8-micro:8.10</ubi-micro.base>
 ```
 
 ### Pushing the image to quay

--- a/jdock/src/test/java/io/quarkus/images/Builders.java
+++ b/jdock/src/test/java/io/quarkus/images/Builders.java
@@ -5,7 +5,7 @@ import io.quarkus.images.modules.*;
 public class Builders {
 
     public static Dockerfile getMandrelDockerFile(String version, String javaVersion, String arch, String sha) {
-        Dockerfile df = Dockerfile.from("registry.access.redhat.com/ubi8/ubi-minimal:8.9");
+        Dockerfile df = Dockerfile.from("registry.access.redhat.com/ubi8/ubi-minimal:8.10");
         df
                 .installer("microdnf")
                 .user("root")
@@ -29,7 +29,7 @@ public class Builders {
     }
 
     public static Dockerfile getGraalVmDockerFile(String version, String javaVersion, String arch, String sha) {
-        Dockerfile df = Dockerfile.from("registry.access.redhat.com/ubi8/ubi-minimal:8.9");
+        Dockerfile df = Dockerfile.from("registry.access.redhat.com/ubi8/ubi-minimal:8.10");
         df
                 .installer("microdnf")
                 .user("root")

--- a/jdock/src/test/java/io/quarkus/images/DistrolessTest.java
+++ b/jdock/src/test/java/io/quarkus/images/DistrolessTest.java
@@ -28,7 +28,7 @@ public class DistrolessTest {
     void testBuildingMicroImage() {
         System.out.println(Dockerfile
                 .multistages()
-                .stage("ubi", Dockerfile.from("registry.access.redhat.com/ubi8/ubi-minimal:8.9"))
+                .stage("ubi", Dockerfile.from("registry.access.redhat.com/ubi8/ubi-minimal:8.10"))
                 .stage("scratch", Dockerfile.from("registry.access.redhat.com/ubi8/ubi-micro"))
                 .stage(Dockerfile.from("scratch")
                         .copyFromStage("ubi", "/usr/lib64/libgcc_s.so.1")

--- a/jdock/src/test/java/io/quarkus/images/MultiMicroTest.java
+++ b/jdock/src/test/java/io/quarkus/images/MultiMicroTest.java
@@ -18,7 +18,7 @@ public class MultiMicroTest {
     @Test
     void test() {
         MultiStageDockerFile micro = Dockerfile.multistages()
-                .stage("ubi", Dockerfile.from("registry.access.redhat.com/ubi8/ubi-minimal:8.9"))
+                .stage("ubi", Dockerfile.from("registry.access.redhat.com/ubi8/ubi-minimal:8.10"))
                 .stage("scratch", Dockerfile.from("registry.access.redhat.com/ubi8/ubi-micro"))
                 .stage(Dockerfile.from("scratch")
                         .copyFromStage("ubi", "/usr/lib64/libgcc_s.so.1")

--- a/jdock/src/test/java/io/quarkus/images/SimpleTest.java
+++ b/jdock/src/test/java/io/quarkus/images/SimpleTest.java
@@ -58,14 +58,14 @@ class SimpleTest {
 
     @Test
     public void testRunWithExecForm() {
-        Dockerfile df = Dockerfile.from("registry.access.redhat.com/ubi8/ubi-minimal:8.9");
+        Dockerfile df = Dockerfile.from("registry.access.redhat.com/ubi8/ubi-minimal:8.10");
         df.exec("/bin/bash", "-c", "echo hello");
         assertThat(df.build()).contains("RUN [ \"/bin/bash\", \"-c\", \"echo hello\" ]\n");
     }
 
     @Test
     public void testRunWithShellForm() {
-        Dockerfile df = Dockerfile.from("registry.access.redhat.com/ubi8/ubi-minimal:8.9");
+        Dockerfile df = Dockerfile.from("registry.access.redhat.com/ubi8/ubi-minimal:8.10");
         df.run("source $HOME/.bashrc", "echo $HOME");
         assertThat(df.build()).contains("RUN source $HOME/.bashrc \\\n && echo $HOME\n");
     }

--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,9 @@
         <maven.compiler.target>17</maven.compiler.target>
 
         <!-- See https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8 -->
-        <ubi-min.base>registry.access.redhat.com/ubi8/ubi-minimal:8.9</ubi-min.base>
-        <!-- See https://catalog.redhat.com/software/containers/ubi8/ubi-micro/5ff3f50a831939b08d1b832a -->
-        <ubi-micro.base>registry.access.redhat.com/ubi8-micro:8.9</ubi-micro.base>
+        <ubi-min.base>registry.access.redhat.com/ubi8/ubi-minimal:8.10</ubi-min.base>
+        <!-- See https://catalog.redhat.com/software/containers/ubi8-micro/601a84aadd19c7786c47c8ea -->
+        <ubi-micro.base>registry.access.redhat.com/ubi8-micro:8.10</ubi-micro.base>
 
         <jdock.dry-run>false</jdock.dry-run>
     </properties>


### PR DESCRIPTION
Bump ubi-micro and ubi-minimal to 8.10 to resolve known vulnerabilities as suggested by RedHat.

fixes #272 

When running

    mvn clean install

locally, Mandrel image build fails. This is most probably related to my local machine having a different CPU architecture (Centos Stream 9 AMD64):

    #6 [ 2/15] RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y tar gzip gcc glibc-devel zlib-devel shadow-utils unzip gcc-c++      && rpm -q tar gzip gcc glibc-devel zlib-devel shadow-utils unzip gcc-c++
    [INFO] 🐋	#6 0.163 exec /bin/sh: exec format error