### PR TITLE
Install DNF package findutils in builder images

### DIFF
--- a/quarkus-graalvm-builder-image/src/main/java/io/quarkus/images/QuarkusGraalVMBuilder.java
+++ b/quarkus-graalvm-builder-image/src/main/java/io/quarkus/images/QuarkusGraalVMBuilder.java
@@ -13,7 +13,7 @@ public class QuarkusGraalVMBuilder {
         Dockerfile df = Dockerfile.from(base);
         df
                 .user("root")
-                .install("tar", "gzip", "gcc", "glibc-devel", "zlib-devel", "shadow-utils", "unzip", "gcc-c++")
+                .install("tar", "gzip", "gcc", "glibc-devel", "zlib-devel", "shadow-utils", "unzip", "gcc-c++", "findutils")
                 .install("glibc-langpack-en")
                 .module(new UsLangModule())
                 .module(new QuarkusUserModule())

--- a/quarkus-mandrel-builder-image/src/main/java/io/quarkus/images/QuarkusMandrelBuilder.java
+++ b/quarkus-mandrel-builder-image/src/main/java/io/quarkus/images/QuarkusMandrelBuilder.java
@@ -14,7 +14,7 @@ public class QuarkusMandrelBuilder {
         df
                 .installer("microdnf")
                 .user("root")
-                .install("tar", "gzip", "gcc", "glibc-devel", "zlib-devel", "shadow-utils", "unzip", "gcc-c++")
+                .install("tar", "gzip", "gcc", "glibc-devel", "zlib-devel", "shadow-utils", "unzip", "gcc-c++", "findutils")
                 .install("glibc-langpack-en")
                 .module(new UsLangModule())
                 .module(new QuarkusUserModule())


### PR DESCRIPTION
The Gradle wrapper scripts necessitate the installation of the 'xargs' command. This command is supplied by the supplementary 'findutils' package.