### PR TITLE
Mandrel for JDK 23 and GraalVM CE for JDK 23

### DIFF
--- a/quarkus-graalvm-builder-image/graalvm.yaml
+++ b/quarkus-graalvm-builder-image/graalvm.yaml
@@ -25,3 +25,12 @@ images:
         sha: ebac1dd96a5e0fbcd1dd9804fa58815f146390a40aae966f02a8c26d1974364f
       - arch: arm64
         sha: 28ca4c815fa68b86141d9dcf1a46c1f58f74dead41de9042de1202337bb014d9
+
+  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-23.0.0
+  - java-version: 23.0.0
+    tags: jdk-23
+    variants:
+      - arch: amd64
+        sha: 440eb64bf548f37086f97d236a028d0a6ccf5cee9ed9caed2f70ded5a68312a0
+      - arch: arm64
+        sha: 42ae53bdb4112d86eb3e12fe6d30a65b800a4ff8a658c7c3bc77e0a678078b20

--- a/quarkus-mandrel-builder-image/mandrel.yaml
+++ b/quarkus-mandrel-builder-image/mandrel.yaml
@@ -17,3 +17,12 @@ images:
         arch: amd64
       - sha: 98dc36277ed4f315449a0a14629d29a4bf61b73c90e9fa900f5bb7f3bea3d3be
         arch: arm64
+
+  - graalvm-version: 24.1.0.0-Final
+    java-version: 23
+    tags: 24.1-java23, 24.1-jdk-23, jdk-23, jdk-23.0.0
+    variants:
+      - sha: 6c0bc63c0d76badae3ff6a58ee64803431857e85dd88adc91a0037217f60fc91
+        arch: amd64
+      - sha: a33a79850d985463eb519b2959011babdc9d738d4603ce9c4489e592f4c1ed2b
+        arch: arm64

--- a/quarkus-native-s2i/graalvm.yaml
+++ b/quarkus-native-s2i/graalvm.yaml
@@ -26,6 +26,15 @@ images:
       - arch: arm64
         sha: 28ca4c815fa68b86141d9dcf1a46c1f58f74dead41de9042de1202337bb014d9
 
+  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-23.0.0
+  - java-version: 23.0.0
+    tags: jdk-23
+    variants:
+      - arch: amd64
+        sha: 440eb64bf548f37086f97d236a028d0a6ccf5cee9ed9caed2f70ded5a68312a0
+      - arch: arm64
+        sha: 42ae53bdb4112d86eb3e12fe6d30a65b800a4ff8a658c7c3bc77e0a678078b20
+
   - graalvm-version: 22.3.3
     java-version: 11
     tag: 22.3-java11


### PR DESCRIPTION
SSIA

https://github.com/graalvm/mandrel/releases/tag/mandrel-24.1.0.0-Final