### PR TITLE
Revert "Update to UBI 9 as base image"

### DIFF
--- a/jdock/src/main/java/io/quarkus/images/MultiArchImage.java
+++ b/jdock/src/main/java/io/quarkus/images/MultiArchImage.java
@@ -48,7 +48,7 @@ public class MultiArchImage {
             if (!dryRun) {
                 // docker buildx build --load --platform linux/arm64 --tag cescoffier/mandrel-java17-22.1.0.0-final-arm64 -f mandrel-java17-22.1.0.0-Final-arm64.Dockerfile .
                 // Build the image (platform-specific)
-                Exec.execute(List.of(Exec.getContainerTool(), "buildx", "build", "--load", "--platform=linux/" + arch, "--tag", imageName,
+                Exec.execute(List.of("docker", "buildx", "build", "--load", "--platform=linux/" + arch, "--tag", imageName,
                         "-f", JDock.dockerFileDir + "/" + fileName, "."),
                         e -> new RuntimeException("Unable to build image for " + dockerfile.getAbsolutePath(), e));
             } else {
@@ -71,7 +71,7 @@ public class MultiArchImage {
 
         for (Map.Entry<String, String> entry : locals.entrySet()) {
             System.out.println("⚙️\tPushing " + entry.getValue() + " (" + entry.getKey() + ")");
-            Exec.execute(List.of(Exec.getContainerTool(), "push", entry.getValue()),
+            Exec.execute(List.of("docker", "push", entry.getValue()),
                     e -> new RuntimeException("Unable to push " + entry.getValue(), e));
         }
 
@@ -86,14 +86,14 @@ public class MultiArchImage {
                     "⚙️\t\t" + entry.getKey() + " => " + entry.getValue());
         }
 
-        List<String> command = new ArrayList<>(Arrays.asList(Exec.getContainerTool(), "manifest", "create", name));
+        List<String> command = new ArrayList<>(Arrays.asList("docker", "manifest", "create", name));
         for (Map.Entry<String, String> entry : archToImage.entrySet()) {
             command.addAll(List.of("--amend", entry.getValue()));
         }
 
         Exec.execute(command, e -> new RuntimeException("Unable to build manifest for " + name, e));
 
-        Exec.execute(List.of(Exec.getContainerTool(), "manifest", "push", name),
+        Exec.execute(List.of("docker", "manifest", "push", name),
                 e -> new RuntimeException("Unable to push manifest for " + name, e));
 
     }

--- a/pom.xml
+++ b/pom.xml
@@ -34,9 +34,10 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
 
-        <ubi8-min.base>registry.access.redhat.com/ubi8/ubi-minimal:8.10</ubi8-min.base>
-        <ubi-min.base>registry.access.redhat.com/ubi9/ubi-minimal:9.5</ubi-min.base>
-        <ubi-micro.base>registry.access.redhat.com/ubi9-micro:9.5</ubi-micro.base>
+        <!-- See https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8 -->
+        <ubi-min.base>registry.access.redhat.com/ubi8/ubi-minimal:8.10</ubi-min.base>
+        <!-- See https://catalog.redhat.com/software/containers/ubi8-micro/601a84aadd19c7786c47c8ea -->
+        <ubi-micro.base>registry.access.redhat.com/ubi8-micro:8.10</ubi-micro.base>
 
         <jdock.dry-run>false</jdock.dry-run>
     </properties>

--- a/quarkus-binary-s2i/pom.xml
+++ b/quarkus-binary-s2i/pom.xml
@@ -34,7 +34,7 @@
                     <args>
                         <argument>--dockerfile-dir=${project.basedir}/target/docker</argument>
                         <argument>--ubi-minimal=${ubi-min.base}</argument>
-                        <argument>--out=quay.io/quarkus/ubi-quarkus-native-binary-s2i:3.0</argument>
+                        <argument>--out=quay.io/quarkus/ubi-quarkus-native-binary-s2i:2.0</argument>
                         <argument>--basedir=${project.basedir}</argument>
                         <argument>--dry-run=${jdock.dry-run}</argument>
                         <argument>--alias=${jdock.alias}</argument>

--- a/quarkus-graalvm-builder-image/pom.xml
+++ b/quarkus-graalvm-builder-image/pom.xml
@@ -26,43 +26,22 @@
                 <artifactId>jbang-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>ubi9</id>
                         <goals>
                             <goal>run</goal>
                         </goals>
                         <phase>package</phase>
-                        <configuration>
-                            <args>
-                                <argument>--dockerfile-dir=${project.basedir}/target/docker</argument>
-                                <argument>--ubi-minimal=${ubi-min.base}</argument>
-                                <argument>--out=quay.io/${org}/ubi-quarkus-graalvmce-builder-image</argument>
-                                <argument>--in=${images.file}</argument>
-                                <argument>--dry-run=${jdock.dry-run}</argument>
-                                <argument>--alias=${jdock.alias}</argument>
-                            </args>
-                        </configuration>
-                    </execution>
-
-                    <execution>
-                        <id>ubi8</id>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <phase>package</phase>
-                        <configuration>
-                            <args>
-                                <argument>--dockerfile-dir=${project.basedir}/target/docker</argument>
-                                <argument>--ubi-minimal=${ubi8-min.base}</argument>
-                                <argument>--out=quay.io/${org}/ubi8-quarkus-graalvmce-builder-image</argument>
-                                <argument>--in=${images.file}</argument>
-                                <argument>--dry-run=${jdock.dry-run}</argument>
-                                <argument>--alias=${jdock.alias}</argument>
-                            </args>
-                        </configuration>
                     </execution>
                 </executions>
-
-
+                <configuration>
+                    <args>
+                        <argument>--dockerfile-dir=${project.basedir}/target/docker</argument>
+                        <argument>--ubi-minimal=${ubi-min.base}</argument>
+                        <argument>--out=quay.io/${org}/ubi-quarkus-graalvmce-builder-image</argument>
+                        <argument>--in=${images.file}</argument>
+                        <argument>--dry-run=${jdock.dry-run}</argument>
+                        <argument>--alias=${jdock.alias}</argument>
+                    </args>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/quarkus-mandrel-builder-image/pom.xml
+++ b/quarkus-mandrel-builder-image/pom.xml
@@ -25,42 +25,22 @@
                 <artifactId>jbang-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>ubi9</id>
                         <goals>
                             <goal>run</goal>
                         </goals>
                         <phase>package</phase>
-                        <configuration>
-                            <args>
-                                <argument>--dockerfile-dir=${project.basedir}/target/docker</argument>
-                                <argument>--ubi-minimal=${ubi-min.base}</argument>
-                                <argument>--out=quay.io/quarkus/ubi-quarkus-mandrel-builder-image</argument>
-                                <argument>--in=${images.file}</argument>
-                                <argument>--dry-run=${jdock.dry-run}</argument>
-                                <argument>--alias=${jdock.alias}</argument>
-                            </args>
-                        </configuration>
-                    </execution>
-
-                    <execution>
-                        <id>ubi8</id>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <phase>package</phase>
-                        <configuration>
-                            <args>
-                                <argument>--dockerfile-dir=${project.basedir}/target/docker</argument>
-                                <argument>--ubi-minimal=${ubi8-min.base}</argument>
-                                <argument>--out=quay.io/quarkus/ubi8-quarkus-mandrel-builder-image</argument>
-                                <argument>--in=${images.file}</argument>
-                                <argument>--dry-run=${jdock.dry-run}</argument>
-                                <argument>--alias=${jdock.alias}</argument>
-                            </args>
-                        </configuration>
                     </execution>
                 </executions>
-
+                <configuration>
+                    <args>
+                        <argument>--dockerfile-dir=${project.basedir}/target/docker</argument>
+                        <argument>--ubi-minimal=${ubi-min.base}</argument>
+                        <argument>--out=quay.io/quarkus/ubi-quarkus-mandrel-builder-image</argument>
+                        <argument>--in=${images.file}</argument>
+                        <argument>--dry-run=${jdock.dry-run}</argument>
+                        <argument>--alias=${jdock.alias}</argument>
+                    </args>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/quarkus-micro-base-image/pom.xml
+++ b/quarkus-micro-base-image/pom.xml
@@ -35,7 +35,7 @@
                         <argument>--dockerfile-dir=${pom.basedir}/target/docker</argument>
                         <argument>--ubi-minimal=${ubi-min.base}</argument>
                         <argument>--ubi-micro=${ubi-micro.base}</argument>
-                        <argument>--out=quay.io/quarkus/quarkus-micro-image:3.0</argument>
+                        <argument>--out=quay.io/quarkus/quarkus-micro-image:2.0</argument>
                         <argument>--dry-run=${jdock.dry-run}</argument>
                         <argument>--alias=${jdock.alias}</argument>
                     </args>


### PR DESCRIPTION
Reverts quarkusio/quarkus-images#283


Building the native executable with a builder using UBI9 requires UBI9 as runtime image. 
Rolling back for now.