### PR TITLE
Provide both UBI 8 and UBI 9 images

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ The images are available on [Quay.io](https://quay.io/organization/quarkus)
 
 To pull these images use:
 
-* `docker pull quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:VERSION` 
-* `docker pull quay.io/quarkus/ubi-quarkus-mandrel-builder-image:VERSION`
-* `docker pull quay.io/quarkus/ubi-quarkus-graalvmce-s2i:VERSION`
-* `docker pull quay.io/quarkus/ubi-quarkus-native-binary-s2i:2.0`
-* `docker pull quay.io/quarkus/quarkus-micro-image:2.0` 
+* `docker pull quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:VERSION` (UBI 8), `docker pull quay.io/quarkus/ubi9-quarkus-graalvmce-builder-image:VERSION` (UBI 9)
+* `docker pull quay.io/quarkus/ubi-quarkus-mandrel-builder-image:VERSION` (UBI 8), `docker pull quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:VERSION` (UBI 9)
+* `docker pull quay.io/quarkus/ubi-quarkus-graalvmce-s2i:VERSION` (UBI 8), `docker pull quay.io/quarkus/ubi9-quarkus-graalvmce-s2i:VERSION` (UBI 9)
+* `docker pull quay.io/quarkus/ubi-quarkus-native-binary-s2i:2.0` (UBI 8), `docker pull quay.io/quarkus/ubi-quarkus-native-binary-s2i:3.0` (UBI 9) 
+* `docker pull quay.io/quarkus/quarkus-micro-image:2.0` (UBI 8), `docker pull quay.io/quarkus/quarkus-micro-image:3.0` (UBI 9)
 * `docker pull quay.io/quarkus/quarkus-distroless-image:2.0`
 
 with _VERSION_ being the version. 
@@ -34,6 +34,8 @@ Navigate to the _tag_ tab on _quay.io_ to see the list of available tabs.
 
 NOTE: You may wonder why we don't use `latest`. It's because `latest` has introduced more problems than benefits especially when reproducing issues.
 For this reason, we recommend using a stable version.
+
+**IMPORTANT**: If you use a UBI9 builder image, you need to use a UBI9 runtime image.
 
 ## Build Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ To pull these images use:
 * `docker pull quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:VERSION` (UBI 8), `docker pull quay.io/quarkus/ubi9-quarkus-graalvmce-builder-image:VERSION` (UBI 9)
 * `docker pull quay.io/quarkus/ubi-quarkus-mandrel-builder-image:VERSION` (UBI 8), `docker pull quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:VERSION` (UBI 9)
 * `docker pull quay.io/quarkus/ubi-quarkus-graalvmce-s2i:VERSION` (UBI 8), `docker pull quay.io/quarkus/ubi9-quarkus-graalvmce-s2i:VERSION` (UBI 9)
-* `docker pull quay.io/quarkus/ubi-quarkus-native-binary-s2i:2.0` (UBI 8), `docker pull quay.io/quarkus/ubi-quarkus-native-binary-s2i:3.0` (UBI 9) 
-* `docker pull quay.io/quarkus/quarkus-micro-image:2.0` (UBI 8), `docker pull quay.io/quarkus/quarkus-micro-image:3.0` (UBI 9)
+* `docker pull quay.io/quarkus/ubi-quarkus-native-binary-s2i:2.0` (UBI 8), `docker pull quay.io/quarkus/ubi9-quarkus-native-binary-s2i:2.0` (UBI 9) 
+* `docker pull quay.io/quarkus/quarkus-micro-image:2.0` (UBI 8), `docker pull quay.io/quarkus/ubi9-quarkus-micro-image:2.0` (UBI 9)
 * `docker pull quay.io/quarkus/quarkus-distroless-image:2.0`
 
 with _VERSION_ being the version. 

--- a/jdock/src/main/java/io/quarkus/images/MultiArchImage.java
+++ b/jdock/src/main/java/io/quarkus/images/MultiArchImage.java
@@ -48,8 +48,10 @@ public class MultiArchImage {
             if (!dryRun) {
                 // docker buildx build --load --platform linux/arm64 --tag cescoffier/mandrel-java17-22.1.0.0-final-arm64 -f mandrel-java17-22.1.0.0-Final-arm64.Dockerfile .
                 // Build the image (platform-specific)
-                Exec.execute(List.of("docker", "buildx", "build", "--load", "--platform=linux/" + arch, "--tag", imageName,
-                        "-f", JDock.dockerFileDir + "/" + fileName, "."),
+                Exec.execute(
+                        List.of(Exec.getContainerTool(), "buildx", "build", "--load", "--platform=linux/" + arch, "--tag",
+                                imageName,
+                                "-f", JDock.dockerFileDir + "/" + fileName, "."),
                         e -> new RuntimeException("Unable to build image for " + dockerfile.getAbsolutePath(), e));
             } else {
                 System.out.println("⚠️️\tSkipping the container build for " + imageName

--- a/jdock/src/main/java/io/quarkus/images/utils/Exec.java
+++ b/jdock/src/main/java/io/quarkus/images/utils/Exec.java
@@ -6,10 +6,13 @@ import org.zeroturnaround.exec.ProcessExecutor;
 import org.zeroturnaround.exec.stream.LogOutputStream;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 public class Exec {
     public static void execute(List<String> command, Function<Exception, RuntimeException> exceptionMapper) {
@@ -84,7 +87,23 @@ public class Exec {
 
     }
 
+    public static String getContainerTool() {
+        if (findExecutable("docker") != null) {
+            return "docker";
+        }
+        if (findExecutable("podman") != null) {
+            return "podman";
+        }
+        throw new IllegalStateException("No container tool found in system path");
+    }
+
     public static void buildAndPush(Buildable df, String name, String arch) {
         build(df, name, arch, false, false); // no dry run when pushing images.
+    }
+
+    public static String findExecutable(String exec) {
+        return Stream.of(System.getenv("PATH").split(Pattern.quote(File.pathSeparator))).map(Paths::get)
+                .map(path -> path.resolve(exec).toFile()).filter(File::exists).findFirst().map(File::getParent)
+                .orElse(null);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,11 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
 
-        <!-- See https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8 -->
-        <ubi-min.base>registry.access.redhat.com/ubi8/ubi-minimal:8.10</ubi-min.base>
-        <!-- See https://catalog.redhat.com/software/containers/ubi8-micro/601a84aadd19c7786c47c8ea -->
-        <ubi-micro.base>registry.access.redhat.com/ubi8-micro:8.10</ubi-micro.base>
+        <ubi8-min.base>registry.access.redhat.com/ubi8/ubi-minimal:8.10</ubi8-min.base>
+        <ubi8-micro.base>registry.access.redhat.com/ubi8-micro:8.10</ubi8-micro.base>
+
+        <ubi9-min.base>registry.access.redhat.com/ubi9/ubi-minimal:9.5</ubi9-min.base>
+        <ubi9-micro.base>registry.access.redhat.com/ubi9-micro:9.5</ubi9-micro.base>
 
         <jdock.dry-run>false</jdock.dry-run>
     </properties>

--- a/quarkus-binary-s2i/pom.xml
+++ b/quarkus-binary-s2i/pom.xml
@@ -51,10 +51,10 @@
                             <args>
                                 <argument>--dockerfile-dir=${project.basedir}/target/docker</argument>
                                 <argument>--ubi-minimal=${ubi9-min.base}</argument>
-                                <argument>--out=quay.io/quarkus/ubi-quarkus-native-binary-s2i:3.0</argument>
+                                <argument>--out=quay.io/quarkus/ubi9-quarkus-native-binary-s2i:2.0</argument>
                                 <argument>--basedir=${project.basedir}</argument>
                                 <argument>--dry-run=${jdock.dry-run}</argument>
-                                <argument>--alias=quay.io/quarkus/ubi-quarkus-native-binary-s2i:3.0-${maven.build.timestamp}</argument>
+                                <argument>--alias=quay.io/quarkus/ubi9-quarkus-native-binary-s2i:2.0-${maven.build.timestamp}</argument>
                             </args>
                         </configuration>
                     </execution>

--- a/quarkus-binary-s2i/pom.xml
+++ b/quarkus-binary-s2i/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <jbang.script>${project.build.sourceDirectory}/io/quarkus/images/Build.java</jbang.script>
-        <jdock.alias></jdock.alias>
+        <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
     </properties>
 
     <build>
@@ -24,22 +24,41 @@
                 <artifactId>jbang-maven-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>ubi8</id>
                         <goals>
                             <goal>run</goal>
                         </goals>
                         <phase>package</phase>
+                        <configuration>
+                            <args>
+                                <argument>--dockerfile-dir=${project.basedir}/target/docker</argument>
+                                <argument>--ubi-minimal=${ubi8-min.base}</argument>
+                                <argument>--out=quay.io/quarkus/ubi-quarkus-native-binary-s2i:2.0</argument>
+                                <argument>--basedir=${project.basedir}</argument>
+                                <argument>--dry-run=${jdock.dry-run}</argument>
+                                <argument>--alias=quay.io/quarkus/ubi-quarkus-native-binary-s2i:2.0-${maven.build.timestamp}</argument>
+                            </args>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>ubi9</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <args>
+                                <argument>--dockerfile-dir=${project.basedir}/target/docker</argument>
+                                <argument>--ubi-minimal=${ubi9-min.base}</argument>
+                                <argument>--out=quay.io/quarkus/ubi-quarkus-native-binary-s2i:3.0</argument>
+                                <argument>--basedir=${project.basedir}</argument>
+                                <argument>--dry-run=${jdock.dry-run}</argument>
+                                <argument>--alias=quay.io/quarkus/ubi-quarkus-native-binary-s2i:3.0-${maven.build.timestamp}</argument>
+                            </args>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <args>
-                        <argument>--dockerfile-dir=${project.basedir}/target/docker</argument>
-                        <argument>--ubi-minimal=${ubi-min.base}</argument>
-                        <argument>--out=quay.io/quarkus/ubi-quarkus-native-binary-s2i:2.0</argument>
-                        <argument>--basedir=${project.basedir}</argument>
-                        <argument>--dry-run=${jdock.dry-run}</argument>
-                        <argument>--alias=${jdock.alias}</argument>
-                    </args>
-                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -60,8 +79,6 @@
             <id>push</id>
             <properties>
                 <jbang.script>${project.build.sourceDirectory}/io/quarkus/images/Push.java</jbang.script>
-                <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
-                <jdock.alias>quay.io/quarkus/ubi-quarkus-native-binary-s2i:2.0-${maven.build.timestamp}</jdock.alias>
             </properties>
         </profile>
     </profiles>

--- a/quarkus-graalvm-builder-image/pom.xml
+++ b/quarkus-graalvm-builder-image/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <jbang.script>${project.build.sourceDirectory}/io/quarkus/images/Build.java</jbang.script>
         <images.file>${project.basedir}/graalvm.yaml</images.file>
-        <jdock.alias></jdock.alias>
+        <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
         <org>quarkus</org>
     </properties>
 
@@ -26,22 +26,41 @@
                 <artifactId>jbang-maven-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>ubi8</id>
                         <goals>
                             <goal>run</goal>
                         </goals>
                         <phase>package</phase>
+                        <configuration>
+                            <args>
+                                <argument>--dockerfile-dir=${project.basedir}/target/docker</argument>
+                                <argument>--ubi-minimal=${ubi8-min.base}</argument>
+                                <argument>--out=quay.io/${org}/ubi-quarkus-graalvmce-builder-image</argument>
+                                <argument>--in=${images.file}</argument>
+                                <argument>--dry-run=${jdock.dry-run}</argument>
+                                <argument>--alias=quay.io/${org}/ubi-quarkus-graalvmce-builder-image:__VERSION__-${maven.build.timestamp}</argument>
+                            </args>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>ubi9</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <args>
+                                <argument>--dockerfile-dir=${project.basedir}/target/docker</argument>
+                                <argument>--ubi-minimal=${ubi9-min.base}</argument>
+                                <argument>--out=quay.io/${org}/ubi9-quarkus-graalvmce-builder-image</argument>
+                                <argument>--in=${images.file}</argument>
+                                <argument>--dry-run=${jdock.dry-run}</argument>
+                                <argument>--alias=quay.io/${org}/ubi9-quarkus-graalvmce-builder-image:__VERSION__-${maven.build.timestamp}</argument>
+                            </args>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <args>
-                        <argument>--dockerfile-dir=${project.basedir}/target/docker</argument>
-                        <argument>--ubi-minimal=${ubi-min.base}</argument>
-                        <argument>--out=quay.io/${org}/ubi-quarkus-graalvmce-builder-image</argument>
-                        <argument>--in=${images.file}</argument>
-                        <argument>--dry-run=${jdock.dry-run}</argument>
-                        <argument>--alias=${jdock.alias}</argument>
-                    </args>
-                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -70,8 +89,6 @@
             <id>push</id>
             <properties>
                 <jbang.script>${project.build.sourceDirectory}/io/quarkus/images/Push.java</jbang.script>
-                <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
-                <jdock.alias>quay.io/${org}/ubi-quarkus-graalvmce-builder-image:__VERSION__-${maven.build.timestamp}</jdock.alias>
             </properties>
         </profile>
 

--- a/quarkus-mandrel-builder-image/mandrel.yaml
+++ b/quarkus-mandrel-builder-image/mandrel.yaml
@@ -1,5 +1,4 @@
 images:
-
   - graalvm-version: 23.1.6.0-Final
     java-version: 21
     tags: 23.1-java21, 23.1-jdk-21, jdk-21, jdk-21.0.6

--- a/quarkus-mandrel-builder-image/pom.xml
+++ b/quarkus-mandrel-builder-image/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <jbang.script>${project.build.sourceDirectory}/io/quarkus/images/Build.java</jbang.script>
         <images.file>${project.basedir}/mandrel.yaml</images.file>
-        <jdock.alias></jdock.alias>
+        <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
     </properties>
 
     <build>
@@ -25,22 +25,41 @@
                 <artifactId>jbang-maven-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>ubi8</id>
                         <goals>
                             <goal>run</goal>
                         </goals>
                         <phase>package</phase>
+                        <configuration>
+                            <args>
+                                <argument>--dockerfile-dir=${project.basedir}/target/docker</argument>
+                                <argument>--ubi-minimal=${ubi8-min.base}</argument>
+                                <argument>--out=quay.io/quarkus/ubi-quarkus-mandrel-builder-image</argument>
+                                <argument>--in=${images.file}</argument>
+                                <argument>--dry-run=${jdock.dry-run}</argument>
+                                <argument>--alias=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:__VERSION__-${maven.build.timestamp}</argument>
+                            </args>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>ubi9</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <args>
+                                <argument>--dockerfile-dir=${project.basedir}/target/docker</argument>
+                                <argument>--ubi-minimal=${ubi9-min.base}</argument>
+                                <argument>--out=quay.io/quarkus/ubi9-quarkus-mandrel-builder-image</argument>
+                                <argument>--in=${images.file}</argument>
+                                <argument>--dry-run=${jdock.dry-run}</argument>
+                                <argument>--alias=quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:__VERSION__-${maven.build.timestamp}</argument>
+                            </args>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <args>
-                        <argument>--dockerfile-dir=${project.basedir}/target/docker</argument>
-                        <argument>--ubi-minimal=${ubi-min.base}</argument>
-                        <argument>--out=quay.io/quarkus/ubi-quarkus-mandrel-builder-image</argument>
-                        <argument>--in=${images.file}</argument>
-                        <argument>--dry-run=${jdock.dry-run}</argument>
-                        <argument>--alias=${jdock.alias}</argument>
-                    </args>
-                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -69,8 +88,6 @@
             <id>push</id>
             <properties>
                 <jbang.script>${project.build.sourceDirectory}/io/quarkus/images/Push.java</jbang.script>
-                <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
-                <jdock.alias>quay.io/quarkus/ubi-quarkus-mandrel-builder-image:__VERSION__-${maven.build.timestamp}</jdock.alias>
             </properties>
         </profile>
         <profile>

--- a/quarkus-micro-base-image/pom.xml
+++ b/quarkus-micro-base-image/pom.xml
@@ -52,9 +52,9 @@
                                 <argument>--dockerfile-dir=${pom.basedir}/target/docker</argument>
                                 <argument>--ubi-minimal=${ubi9-min.base}</argument>
                                 <argument>--ubi-micro=${ubi9-micro.base}</argument>
-                                <argument>--out=quay.io/quarkus/quarkus-micro-image:3.0</argument>
+                                <argument>--out=quay.io/quarkus/ubi9-quarkus-micro-image:2.0</argument>
                                 <argument>--dry-run=${jdock.dry-run}</argument>
-                                <argument>--alias=quay.io/quarkus/quarkus-micro-image:3.0-${maven.build.timestamp}</argument>
+                                <argument>--alias=quay.io/quarkus/ubi9-quarkus-micro-image:2.0-${maven.build.timestamp}</argument>
                             </args>
                         </configuration>
                     </execution>

--- a/quarkus-micro-base-image/pom.xml
+++ b/quarkus-micro-base-image/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <jbang.script>${project.build.sourceDirectory}/io/quarkus/images/Build.java</jbang.script>
-        <jdock.alias></jdock.alias>
+        <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
     </properties>
 
     <build>
@@ -24,22 +24,41 @@
                 <artifactId>jbang-maven-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>ubi8</id>
                         <goals>
                             <goal>run</goal>
                         </goals>
                         <phase>package</phase>
+                        <configuration>
+                            <args>
+                                <argument>--dockerfile-dir=${pom.basedir}/target/docker</argument>
+                                <argument>--ubi-minimal=${ubi8-min.base}</argument>
+                                <argument>--ubi-micro=${ubi8-micro.base}</argument>
+                                <argument>--out=quay.io/quarkus/quarkus-micro-image:2.0</argument>
+                                <argument>--dry-run=${jdock.dry-run}</argument>
+                                <argument>--alias=quay.io/quarkus/quarkus-micro-image:2.0-${maven.build.timestamp}</argument>
+                            </args>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>ubi9</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <args>
+                                <argument>--dockerfile-dir=${pom.basedir}/target/docker</argument>
+                                <argument>--ubi-minimal=${ubi9-min.base}</argument>
+                                <argument>--ubi-micro=${ubi9-micro.base}</argument>
+                                <argument>--out=quay.io/quarkus/quarkus-micro-image:3.0</argument>
+                                <argument>--dry-run=${jdock.dry-run}</argument>
+                                <argument>--alias=quay.io/quarkus/quarkus-micro-image:3.0-${maven.build.timestamp}</argument>
+                            </args>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <args>
-                        <argument>--dockerfile-dir=${pom.basedir}/target/docker</argument>
-                        <argument>--ubi-minimal=${ubi-min.base}</argument>
-                        <argument>--ubi-micro=${ubi-micro.base}</argument>
-                        <argument>--out=quay.io/quarkus/quarkus-micro-image:2.0</argument>
-                        <argument>--dry-run=${jdock.dry-run}</argument>
-                        <argument>--alias=${jdock.alias}</argument>
-                    </args>
-                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -59,9 +78,7 @@
         <profile>
             <id>push</id>
             <properties>
-                <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
                 <jbang.script>${project.build.sourceDirectory}/io/quarkus/images/Push.java</jbang.script>
-                <jdock.alias>quay.io/quarkus/quarkus-micro-image:2.0-${maven.build.timestamp}</jdock.alias>
             </properties>
         </profile>
     </profiles>

--- a/quarkus-native-s2i/pom.xml
+++ b/quarkus-native-s2i/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <jbang.script>${project.build.sourceDirectory}/io/quarkus/images/Build.java</jbang.script>
-        <jdock.alias></jdock.alias>
+        <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
     </properties>
 
     <build>
@@ -24,23 +24,41 @@
                 <artifactId>jbang-maven-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>ubi8</id>
                         <goals>
                             <goal>run</goal>
                         </goals>
                         <phase>package</phase>
+                        <configuration>
+                            <args>
+                                <argument>--dockerfile-dir=${project.basedir}/target/docker</argument>
+                                <argument>--ubi-minimal=${ubi8-min.base}</argument>
+                                <argument>--out=quay.io/quarkus/ubi-quarkus-graalvmce-s2i</argument>
+                                <argument>--in=${project.basedir}/graalvm.yaml</argument>
+                                <argument>--basedir=${project.basedir}</argument>
+                                <argument>--dry-run=${jdock.dry-run}</argument>
+                            </args>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>ubi9</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <args>
+                                <argument>--dockerfile-dir=${project.basedir}/target/docker</argument>
+                                <argument>--ubi-minimal=${ubi9-min.base}</argument>
+                                <argument>--out=quay.io/quarkus/ubi9-quarkus-graalvmce-s2i</argument>
+                                <argument>--in=${project.basedir}/graalvm.yaml</argument>
+                                <argument>--basedir=${project.basedir}</argument>
+                                <argument>--dry-run=${jdock.dry-run}</argument>
+                            </args>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <args>
-                        <argument>--dockerfile-dir=${project.basedir}/target/docker</argument>
-                        <argument>--ubi-minimal=${ubi-min.base}</argument>
-                        <argument>--out=quay.io/quarkus/ubi-quarkus-graalvmce-s2i</argument>
-                        <argument>--in=${project.basedir}/graalvm.yaml</argument>
-                        <argument>--basedir=${project.basedir}</argument>
-                        <argument>--dry-run=${jdock.dry-run}</argument>
-                        <argument>--alias=${jdock.alias}</argument>
-                    </args>
-                </configuration>
+
             </plugin>
         </plugins>
     </build>
@@ -69,8 +87,6 @@
             <id>push</id>
             <properties>
                 <jbang.script>${project.build.sourceDirectory}/io/quarkus/images/Push.java</jbang.script>
-                <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
-                <jdock.alias>quay.io/quarkus/ubi-quarkus-graalvmce-s2i:2.0-${maven.build.timestamp}</jdock.alias>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
For builder images, it still delivers UBI8 (alongside UBI9). UBI9 builder images start with `ubi9`

Runtime images and S2I switched to version 3.0. The version 2.0 (UBI8) are still delivered.