### PR TITLE
JDK 24 release, Testing updates for new JDK image

### DIFF
--- a/quarkus-graalvm-builder-image/graalvm.yaml
+++ b/quarkus-graalvm-builder-image/graalvm.yaml
@@ -16,3 +16,12 @@ images:
         sha: 0cf63e88153b759136947c14f0042c515ae1ff9abf346f143dc47af065b1d6dd
       - arch: arm64
         sha: 70d0ee8cb1922fbfe5a5db6a93360f63bbf0bdf72a6ca1f9b00906e600628c19
+
+  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-24.0.0
+  - java-version: 24.0.0
+    tags: jdk-24
+    variants:
+      - arch: amd64
+        sha: 6476257f3e8e652860c9dfcfea213961ec88a74d7025299d3e95b9441ee5213a
+      - arch: arm64
+        sha: d19c49df72b0d5017bed0467a7053baff3ee83cdff93a4341b3910fab45c68a4

--- a/quarkus-mandrel-builder-image/mandrel.yaml
+++ b/quarkus-mandrel-builder-image/mandrel.yaml
@@ -16,3 +16,12 @@ images:
         arch: amd64
       - sha: a868a70d66a793c371b49235e263ca7fdd7669467d52b4e5f54def753676b515
         arch: arm64
+
+  - graalvm-version: 24.2.0.0-Final
+    java-version: 24
+    tags: 24.2-java24, 24.2-jdk-24, jdk-24, jdk-24.0.0
+    variants:
+      - sha: c5da72468bb83095557bfca8b91eb130753e1b29531109dea0727c51da6d63d1
+        arch: amd64
+      - sha: f6f9285a8e59c718b44e45cbb2e555d3e21af80fc42e3a6860e6840a8b66be8b
+        arch: arm64

--- a/quarkus-mandrel-builder-image/src/main/java/io/quarkus/images/Test.java
+++ b/quarkus-mandrel-builder-image/src/main/java/io/quarkus/images/Test.java
@@ -21,6 +21,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardOpenOption.APPEND;
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
 
@@ -87,6 +88,11 @@ public class Test implements Callable<Integer> {
             testsuiteProcess.waitFor(10, TimeUnit.MINUTES); // We might be downloading 6+ base images on first run.
             if (testsuiteProcess.exitValue() != 0) {
                 System.err.println("Failed to run the mandrel-integration-tests.");
+                final String summaryFile = System.getenv("DOCKER_GHA_SUMMARY_NAME");
+                if (summaryFile != null) {
+                    final String summary = "│   ├❌ Testsuite failed to start for " + image.fullname(config) + "\n";
+                    Files.writeString(Path.of(summaryFile), summary, UTF_8, CREATE, APPEND);
+                }
             }
             returnCode = returnCode + testsuiteProcess.exitValue();
             System.out.println("=== BEGIN DETAILS === " + image.fullname(config) + "\n" +

--- a/quarkus-mandrel-builder-image/src/main/java/io/quarkus/images/Test.java
+++ b/quarkus-mandrel-builder-image/src/main/java/io/quarkus/images/Test.java
@@ -80,7 +80,8 @@ public class Test implements Callable<Integer> {
                     "mvn", "clean", "verify",
                     "-Ptestsuite-builder-image",
                     "-Dtest=AppReproducersTest#imageioAWTContainerTest",
-                    "-Dquarkus.native.builder-image=" + image.fullname(config),
+                    // Why -amd64 suffix? At the time of testing, the manifests are not pushed to the registry yet.
+                    "-Dquarkus.native.builder-image=" + image.fullname(config) + "-amd64",
                     "-Dquarkus.native.container-runtime=docker",
                     "-Drootless.container-runtime=false",
                     "-Ddocker.with.sudo=false");

--- a/quarkus-native-s2i/graalvm.yaml
+++ b/quarkus-native-s2i/graalvm.yaml
@@ -43,21 +43,3 @@ images:
         sha: 6476257f3e8e652860c9dfcfea213961ec88a74d7025299d3e95b9441ee5213a
       - arch: arm64
         sha: d19c49df72b0d5017bed0467a7053baff3ee83cdff93a4341b3910fab45c68a4
-
-  - graalvm-version: 22.3.3
-    java-version: 11
-    tag: 22.3-java11
-    variants:
-      - sha: 959154e1248108dcd6eb279032cecdd2a6076bdebb345de9532681185231d255
-        arch: amd64
-      - sha: 177d682f3455d00fa2491246e809d9c9b743187a82115ad3f578998b4935d5a1
-        arch: arm64
-
-  - graalvm-version: 22.3.3
-    java-version: 17
-    tag: 22.3-java17
-    variants:
-      - sha: ebc3200057ca865f0389abceb210f2d4c77d02cf09acf5ede1631d6b70924b00
-        arch: amd64
-      - sha: 1a6bf2ea2715aa8feacc81a78c41b7f2fe6f94cdde56696f72238474f1fc2598
-        arch: arm64

--- a/quarkus-native-s2i/graalvm.yaml
+++ b/quarkus-native-s2i/graalvm.yaml
@@ -35,6 +35,15 @@ images:
       - arch: arm64
         sha: 70d0ee8cb1922fbfe5a5db6a93360f63bbf0bdf72a6ca1f9b00906e600628c19
 
+  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-24.0.0
+  - java-version: 24.0.0
+    tags: jdk-24
+    variants:
+      - arch: amd64
+        sha: 6476257f3e8e652860c9dfcfea213961ec88a74d7025299d3e95b9441ee5213a
+      - arch: arm64
+        sha: d19c49df72b0d5017bed0467a7053baff3ee83cdff93a4341b3910fab45c68a4
+
   - graalvm-version: 22.3.3
     java-version: 11
     tag: 22.3-java11


### PR DESCRIPTION
This PR should add JDK 24 as a new release.

I keep having problem with docker manifest create as if it was refusing to work with locally built and tagged images, looking for images remotely - obviously images that have never been there in the registry as this is the very first release of JDK 24 tags.

e.g. 

```
[INFO] ⚙️	Creating manifest for quay.io/quarkus/ubi-quarkus-mandrel-builder-image:24.2-java24 including the following images:
[INFO] ⚙️		arm64 => quay.io/quarkus/ubi-quarkus-mandrel-builder-image:24.2.0.0-Final-java24-arm64
[INFO] ⚙️		amd64 => quay.io/quarkus/ubi-quarkus-mandrel-builder-image:24.2.0.0-Final-java24-amd64
[INFO] 🐋	no such manifest: quay.io/quarkus/ubi-quarkus-mandrel-builder-image:24.2.0.0-Final-java24-amd64
...
[INFO] Caused by: org.zeroturnaround.exec.InvalidExitValueException: Unexpected exit value: 1, allowed exit values: [0], executed command [docker, manifest, create, quay.io/quarkus/ubi-quarkus-mandrel-builder-image:24.2-java24, --amend, quay.io/quarkus/ubi-quarkus-mandrel-builder-image:24.2.0.0-Final-java24-amd64, --amend, quay.io/quarkus/ubi-quarkus-mandrel-builder-image:24.2.0.0-Final-java24-arm64]
```

Whereas those tags exist locally: 

```
 REPOSITORY                                          TAG                           IMAGE ID       CREATED              SIZE
quay.io/quarkus/ubi-quarkus-mandrel-builder-image   24.2.0.0-Final-java24-amd64   4712ab681931   25 seconds ago       1.06GB
quay.io/quarkus/ubi-quarkus-mandrel-builder-image   24.2.0.0-Final-java24-arm64   7a98791a02a5   About a minute ago   1.05GB
quay.io/quarkus/ubi-quarkus-mandrel-builder-image   24.1.2.0-Final-java23-amd64   11143a958dc5   2 minutes ago        1.19GB
quay.io/quarkus/ubi-quarkus-mandrel-builder-image   24.1.2.0-Final-java23-arm64   2b00ca84534e   2 minutes ago        1.18GB
moby/buildkit                                       buildx-stable-1               3c2d38015344   22 hours ago         209MB
tonistiigi/binfmt                                   latest                        69b92b14f1eb   3 weeks ago          80.9MB
```
WIP....

Update:

Resolved. I stopped trying to build and use the manifests locally and I switched the testing to use the actual image tag, not he manifest name. It works now.