### PR TITLE
April 2025 CPU, JDK 21, 24

### DIFF
--- a/quarkus-graalvm-builder-image/graalvm.yaml
+++ b/quarkus-graalvm-builder-image/graalvm.yaml
@@ -1,27 +1,9 @@
 images:
-  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-21.0.2
-  - java-version: 21.0.2
-    tags: jdk-21
-    variants:
-      - arch: amd64
-        sha: b048069aaa3a99b84f5b957b162cc181a32a4330cbc35402766363c5be76ae48
-      - arch: arm64
-        sha: a34be691ce68f0acf4655c7c6c63a9a49ed276a11859d7224fd94fc2f657cd7a
-
-  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-23.0.2
-  - java-version: 23.0.2
-    tags: jdk-23
-    variants:
-      - arch: amd64
-        sha: 0cf63e88153b759136947c14f0042c515ae1ff9abf346f143dc47af065b1d6dd
-      - arch: arm64
-        sha: 70d0ee8cb1922fbfe5a5db6a93360f63bbf0bdf72a6ca1f9b00906e600628c19
-
-  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-24.0.0
-  - java-version: 24.0.0
+  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-24.0.1
+  - java-version: 24.0.1
     tags: jdk-24
     variants:
       - arch: amd64
-        sha: 6476257f3e8e652860c9dfcfea213961ec88a74d7025299d3e95b9441ee5213a
+        sha: d2c544de672e400476a09c8f1da79ecc6b774a9441e234948542c3b3e6a84bde
       - arch: arm64
-        sha: d19c49df72b0d5017bed0467a7053baff3ee83cdff93a4341b3910fab45c68a4
+        sha: a3d1be8fadfb0d3df632252301f79a9b02b47e523da66539d370c62e683d762e

--- a/quarkus-mandrel-builder-image/mandrel.yaml
+++ b/quarkus-mandrel-builder-image/mandrel.yaml
@@ -1,27 +1,20 @@
 images:
-  - graalvm-version: 23.1.6.0-Final
+  # https://github.com/graalvm/mandrel/releases/tag/mandrel-23.1.7.0-Final
+  - graalvm-version: 23.1.7.0-Final
     java-version: 21
-    tags: 23.1-java21, 23.1-jdk-21, jdk-21, jdk-21.0.6
+    tags: 23.1-java21, 23.1-jdk-21, jdk-21, jdk-21.0.7
     variants:
-      - sha: b7d27a6917efcd6c7717f0fe107db5467789c2128dfbe0adf95ea72869ba14c0
+      - sha: a9fac281199d89da8c296cf8426a6d87a07aa9c6ca474bb6f34ab9ba88ae0d55
         arch: amd64
-      - sha: b58d5d4535fb17680c5a396115ad5c10d385fbe5f7661e300b7282bb0991f0a2
+      - sha: 25f47c3b41491e282c92f074a1b3af1940916be90ee87a9ef09d85ded5fb6a19
         arch: arm64
 
-  - graalvm-version: 24.1.2.0-Final
-    java-version: 23
-    tags: 24.1-java23, 24.1-jdk-23, jdk-23, jdk-23.0.2
-    variants:
-      - sha: b370586a4f0379aa76ecc788595177be501720f9a94300255fb083536c64b3a5
-        arch: amd64
-      - sha: a868a70d66a793c371b49235e263ca7fdd7669467d52b4e5f54def753676b515
-        arch: arm64
-
-  - graalvm-version: 24.2.0.0-Final
+  # https://github.com/graalvm/mandrel/releases/tag/mandrel-24.2.1.0-Final
+  - graalvm-version: 24.2.1.0-Final
     java-version: 24
-    tags: 24.2-java24, 24.2-jdk-24, jdk-24, jdk-24.0.0
+    tags: 24.2-java24, 24.2-jdk-24, jdk-24, jdk-24.0.1
     variants:
-      - sha: c5da72468bb83095557bfca8b91eb130753e1b29531109dea0727c51da6d63d1
+      - sha: fe60d0227695509879e6115afb9cd130775d9d712b382e3fb1f6dfad91687049
         arch: amd64
-      - sha: f6f9285a8e59c718b44e45cbb2e555d3e21af80fc42e3a6860e6840a8b66be8b
+      - sha: 36f5bfa6067201516ccb87066e419559a75966d343b42d73e0a306cdcfd2f567
         arch: arm64

--- a/quarkus-native-s2i/graalvm.yaml
+++ b/quarkus-native-s2i/graalvm.yaml
@@ -1,45 +1,9 @@
 images:
-  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-17.0.8
-  - java-version: 17.0.8
-    tags: jdk-17
-    variants:
-      - arch: amd64
-        sha: 1dffdf5c7cc5bf38558e9f093eef6a14072a6dff0be3a9906208b37b53ecc009
-      - arch: arm64
-        sha: c4f26318114d6bd125cc95ee070289afdd42c6683867adf832f2ab2819c3b685
-
-  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-21.0.2
-  - java-version: 21.0.2
-    tags: jdk-21
-    variants:
-      - arch: amd64
-        sha: b048069aaa3a99b84f5b957b162cc181a32a4330cbc35402766363c5be76ae48
-      - arch: arm64
-        sha: a34be691ce68f0acf4655c7c6c63a9a49ed276a11859d7224fd94fc2f657cd7a
-
-  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-22.0.2
-  - java-version: 22.0.2
-    tags: jdk-22
-    variants:
-      - arch: amd64
-        sha: ebac1dd96a5e0fbcd1dd9804fa58815f146390a40aae966f02a8c26d1974364f
-      - arch: arm64
-        sha: 28ca4c815fa68b86141d9dcf1a46c1f58f74dead41de9042de1202337bb014d9
-
-  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-23.0.2
-  - java-version: 23.0.2
-    tags: jdk-23
-    variants:
-      - arch: amd64
-        sha: 0cf63e88153b759136947c14f0042c515ae1ff9abf346f143dc47af065b1d6dd
-      - arch: arm64
-        sha: 70d0ee8cb1922fbfe5a5db6a93360f63bbf0bdf72a6ca1f9b00906e600628c19
-
-  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-24.0.0
-  - java-version: 24.0.0
+  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-24.0.1
+  - java-version: 24.0.1
     tags: jdk-24
     variants:
       - arch: amd64
-        sha: 6476257f3e8e652860c9dfcfea213961ec88a74d7025299d3e95b9441ee5213a
+        sha: d2c544de672e400476a09c8f1da79ecc6b774a9441e234948542c3b3e6a84bde
       - arch: arm64
-        sha: d19c49df72b0d5017bed0467a7053baff3ee83cdff93a4341b3910fab45c68a4
+        sha: a3d1be8fadfb0d3df632252301f79a9b02b47e523da66539d370c62e683d762e


### PR DESCRIPTION
Updates JDK 21 and JDK 24.
Removes obsoleted and unmaintained releases.

@cescoffier What's your take on s2i? It used to have JDK 21 from GraalVM CE, but that has been unmainained for a long time. I removed it in this PR. Should we make s2i to use Mandrel JDK 21 distro?