### PR TITLE
January 2026 CPU, JDK 25.0.2, 21.0.10

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -43,7 +43,9 @@ jobs:
     steps:
     - name: Install Podman and qemu
       run: |
+        sudo apt-get update
         sudo apt-get install podman qemu-user-static binfmt-support
+        sudo update-binfmts --enable qemu-aarch64
         sudo systemctl restart systemd-binfmt
     - name: Re-claim some disk space
       run: |
@@ -51,7 +53,8 @@ jobs:
         sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android \
         /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup
         sudo apt-get clean
-        yes | podman system prune -a
+        podman system prune -a -f
+        sudo podman system prune -a -f
         df -h
     - uses: actions/checkout@v6
     - uses: actions/setup-java@v5

--- a/.github/workflows/dev-images.yml
+++ b/.github/workflows/dev-images.yml
@@ -20,7 +20,9 @@ jobs:
     steps:
     - name: Install Podman and qemu
       run: |
+        sudo apt-get update
         sudo apt-get install podman qemu-user-static binfmt-support
+        sudo update-binfmts --enable qemu-aarch64
         sudo systemctl restart systemd-binfmt
     - name: Re-claim some disk space
       run: |
@@ -28,7 +30,8 @@ jobs:
         sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android \
         /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup
         sudo apt-get clean
-        yes | podman system prune -a
+        podman system prune -a -f
+        sudo podman system prune -a -f
         df -h
     - uses: actions/checkout@v1
     - uses: actions/setup-java@v3

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -31,7 +31,9 @@ jobs:
     steps:
       - name: Install Podman and qemu
         run: |
+          sudo apt-get update
           sudo apt-get install podman qemu-user-static binfmt-support
+          sudo update-binfmts --enable qemu-aarch64
           sudo systemctl restart systemd-binfmt
       - name: Re-claim some disk space
         run: |
@@ -39,7 +41,8 @@ jobs:
           sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android \
           /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup
           sudo apt-get clean
-          yes | podman system prune -a
+          podman system prune -a -f
+          sudo podman system prune -a -f
           df -h
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v3

--- a/quarkus-graalvm-builder-image/graalvm.yaml
+++ b/quarkus-graalvm-builder-image/graalvm.yaml
@@ -1,9 +1,9 @@
 images:
-  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-25.0.1
-  - java-version: 25.0.1
+  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-25.0.2
+  - java-version: 25.0.2
     tags: jdk-25
     variants:
       - arch: amd64
-        sha: 01e39fe1a87f28b842a3e4e3b77be9b544dca3a58fa6e93b924a6106c8bac7fb
+        sha: e0be791c8fda4d03b6b0a0cb824fef3149736170057b3a515252b44419606af0
       - arch: arm64
-        sha: 7aa0b9935a80e67f37c6025678393dbd123bb6f2226811decbc1a13093fc8ae2
+        sha: b4580d9f223d0a4b3a1757e58b18ff4c1db950e67e105fc5cb741457d2384a71

--- a/quarkus-mandrel-builder-image/mandrel.yaml
+++ b/quarkus-mandrel-builder-image/mandrel.yaml
@@ -1,20 +1,20 @@
 images:
-  # https://github.com/graalvm/mandrel/releases/tag/mandrel-23.1.9.0-Final
-  - graalvm-version: 23.1.9.0-Final
+  # https://github.com/graalvm/mandrel/releases/tag/mandrel-23.1.10.0-Final
+  - graalvm-version: 23.1.10.0-Final
     java-version: 21
-    tags: 23.1-java21, 23.1-jdk-21, jdk-21, jdk-21.0.9
+    tags: 23.1-java21, 23.1-jdk-21, jdk-21, jdk-21.0.10
     variants:
-      - sha: 3f3ad5078af27ca8de6e80545bab8d61adda7c968eb84a73ba0beac6ed247a27
+      - sha: a36713a92b0c8476b4feead0e28b1221c2af53aa9aaa43b7613fd4bd88d84b9d
         arch: amd64
-      - sha: 60be84bd6ae4bef3bb0378d8844769e173b34a0b66d4fe9faf98ac39072d1408
+      - sha: fe969e29f3209f31864740f5373ba421ca7bbfcc078516b54f2db3c2c52a41d3
         arch: arm64
 
-  # https://github.com/graalvm/mandrel/releases/tag/mandrel-25.0.1.0-Final
-  - graalvm-version: 25.0.1.0-Final
+  # https://github.com/graalvm/mandrel/releases/tag/mandrel-25.0.2.0-Final
+  - graalvm-version: 25.0.2.0-Final
     java-version: 25
-    tags: 25.0-java25, 25.0-jdk-25, jdk-25, jdk-25.0.1
+    tags: 25.0-java25, 25.0-jdk-25, jdk-25, jdk-25.0.2
     variants:
-      - sha: d5b49874a3fe83d69156832d203c13f05f4de170a62f0f6383b6c17aacde77e4
+      - sha: 93c43bc1848860b55b0c109d33dee04829bf4805ab87c886cfe3ea99f0fabc88
         arch: amd64
-      - sha: 3ae231e018d2d4605383904c6a5073c454e0cc65e3b9580276c29368681524f3
+      - sha: cd35e69b328621cca07de110f5bd307e04e4614ddc4c3d00e35393adb28c39e8
         arch: arm64

--- a/quarkus-mandrel-builder-image/src/main/java/io/quarkus/images/Test.java
+++ b/quarkus-mandrel-builder-image/src/main/java/io/quarkus/images/Test.java
@@ -86,9 +86,10 @@ public class Test implements Callable<Integer> {
                     "-Ptestsuite-builder-image",
                     "-Dtest=AppReproducersTest#imageioAWTContainerTest",
                     "-Dquarkus.native.builder-image=" + builderImage,
-                    "-Dquarkus.native.container-runtime=docker",
-                    "-Drootless.container-runtime=false",
-                    "-Ddocker.with.sudo=false");
+                    "-Dquarkus.native.container-runtime=podman",
+                    "-Drootless.container-runtime=true",
+                    "-Dpodman.with.sudo=false");
+            System.out.println("Running: " + testsuite);
             final Process testsuiteProcess = runCommand(testsuite, tsDir.toFile());
             testsuiteProcess.waitFor(10, TimeUnit.MINUTES); // We might be downloading 6+ base images on first run.
             if (testsuiteProcess.exitValue() != 0) {

--- a/quarkus-native-s2i/graalvm.yaml
+++ b/quarkus-native-s2i/graalvm.yaml
@@ -1,9 +1,9 @@
 images:
-  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-25.0.1
-  - java-version: 25.0.1
+  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-25.0.2
+  - java-version: 25.0.2
     tags: jdk-25
     variants:
       - arch: amd64
-        sha: 01e39fe1a87f28b842a3e4e3b77be9b544dca3a58fa6e93b924a6106c8bac7fb
+        sha: e0be791c8fda4d03b6b0a0cb824fef3149736170057b3a515252b44419606af0
       - arch: arm64
-        sha: 7aa0b9935a80e67f37c6025678393dbd123bb6f2226811decbc1a13093fc8ae2
+        sha: b4580d9f223d0a4b3a1757e58b18ff4c1db950e67e105fc5cb741457d2384a71


### PR DESCRIPTION
157069e5 updates release hashes, versions

Tests were failing because `apt-get` wasn't able to install packages, i.e. needed apt-update to refresh. Wasn't needed before, GHA runner Ubuntu thing.
Then the Mandrel Integration Testsuite wasn't able to find the container image that was just built in the previous step. I debugged it to the fact that the switch to `podman` left the testsuite running `docker`. While it used to work before, e.g. aliasing? 23.1.9.0 image cached?, it hasn't been working now. I switched to `podman` and it didn't help. The reason is that the `podman` is rootless in this GHA while the testsuite defaults to `sudo` (some aspects of the TS, irrelevant to this tests, require it e.g. to test attaching gdb to a living container). Correct settings for the Mandrel testsuite to expect a rootless env fixed it. Now the image is built and found by the testsuite in the same context of the user running the action.

86cb468 takes care of this rootless setting. 

