### PR TITLE
July 2026 CPU, JDK 25.0.4, 21.0.12, GraalVM, symlink

### DIFF
--- a/jdock-variant-helper/src/main/java/io/quarkus/images/config/Config.java
+++ b/jdock-variant-helper/src/main/java/io/quarkus/images/config/Config.java
@@ -30,6 +30,12 @@ public class Config {
         @JsonProperty("java-version")
         public String javaVersion;
 
+        /**
+         * Optional GitHub release tag for the new GraalVM Community Innovation-release naming scheme.
+         */
+        @JsonProperty("graalvm-release-tag") // Optional, can be null.
+        public String graalvmReleaseTag;
+
         // Optional, can be null
         public String tag;
 
@@ -39,6 +45,10 @@ public class Config {
 
         public String graalvmVersion() {
             return graalvmVersion;
+        }
+
+        public String graalvmReleaseTag() {
+            return graalvmReleaseTag;
         }
 
         public List<String> tags() {

--- a/jdock/src/main/java/io/quarkus/images/modules/GraalVMModule.java
+++ b/jdock/src/main/java/io/quarkus/images/modules/GraalVMModule.java
@@ -5,6 +5,7 @@ import io.quarkus.images.artifacts.Artifact;
 import io.quarkus.images.commands.*;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 public class GraalVMModule extends AbstractModule {
     public static final String GRAALVM_HOME = "/opt/graalvm";
@@ -17,6 +18,15 @@ public class GraalVMModule extends AbstractModule {
      * or the new ones (17/20...)
      */
     private final boolean isLegacyGraalVm;
+
+    /**
+     * Indicates whether to use the new GraalVM Community Innovation naming.
+     * Example: graalvm-community-jdk-25i2-25.0.4_linux-x64_bin.tar.gz
+     * at tag jdk-25.0.4
+     */
+    private final boolean isNewCommunityNaming;
+
+    private static final Pattern COMMUNITY_VERSION_LABEL = Pattern.compile("^\\d+i\\d+$");
 
     private static final String TEMPLATE = """
             tar xzf %s -C /opt \\
@@ -31,17 +41,22 @@ public class GraalVMModule extends AbstractModule {
     private final String graalvmVersion;
 
     public GraalVMModule(String version, String arch, String javaVersion, String sha) {
+        this(version, arch, javaVersion, sha, null);
+    }
+
+    public GraalVMModule(String version, String arch, String javaVersion, String sha, String releaseTag) {
         super("graalvm",
                 version == null ? "jdk-" + javaVersion + "-" + arch
                         : arch != null ? version + "-java" + javaVersion + "-" + arch
                                 : version + "-java" + javaVersion + "-amd64");
 
-        isLegacyGraalVm = version != null;
+        isNewCommunityNaming = version != null && COMMUNITY_VERSION_LABEL.matcher(version).matches();
+        isLegacyGraalVm = version != null && !isNewCommunityNaming;
         if (arch == null) {
             arch = "amd64";
         } else if (arch.equalsIgnoreCase("arm64")) {
             arch = "aarch64";
-        } else if (version == null) {
+        } else if (version == null || isNewCommunityNaming) {
             arch = "x64";
         }
 
@@ -49,6 +64,10 @@ public class GraalVMModule extends AbstractModule {
         if (isLegacyGraalVm) {
             this.filename = "graalvm-java-%s-linux-%s-%s.tar.gz"
                     .formatted(javaVersion, arch, version);
+        } else if (isNewCommunityNaming) {
+            // e.g. graalvm-community-jdk-25i2-25.0.4_linux-x64_bin.tar.gz
+            this.filename = "graalvm-community-jdk-%s-%s_linux-%s_bin.tar.gz"
+                    .formatted(version, javaVersion, arch);
         } else {
             this.filename = "graalvm-jdk-%s-linux-%s.tar.gz"
                     .formatted(javaVersion, arch);
@@ -57,12 +76,28 @@ public class GraalVMModule extends AbstractModule {
         if (isLegacyGraalVm) {
             this.url = "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-%s/graalvm-ce-java%s-linux-%s-%s.tar.gz"
                     .formatted(version, javaVersion, arch, version);
+        } else if (isNewCommunityNaming) {
+            // Release tag is e.g. graal-25.2.4 distinct from the java version (25.0.4)
+            if (releaseTag == null) {
+                throw new IllegalArgumentException(
+                        "releaseTag must not be null for new-community innovation-release naming (version=" + version + ")");
+            }
+            this.url = "https://github.com/graalvm/graalvm-ce-builds/releases/download/%s/graalvm-community-jdk-%s-%s_linux-%s_bin.tar.gz"
+                    .formatted(releaseTag, version, javaVersion, arch);
         } else {
             this.url = "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-%s/graalvm-community-jdk-%s_linux-%s_bin.tar.gz"
                     .formatted(javaVersion, javaVersion, arch);
         }
         this.sha = sha;
         this.graalvmVersion = version == null ? javaVersion : version;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getFilename() {
+        return filename;
     }
 
     @Override

--- a/jdock/src/main/java/io/quarkus/images/modules/MandrelModule.java
+++ b/jdock/src/main/java/io/quarkus/images/modules/MandrelModule.java
@@ -12,6 +12,7 @@ import io.quarkus.images.utils.Exec;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
@@ -36,6 +37,16 @@ public class MandrelModule extends AbstractModule {
                 && tar xzf %s -C %s --strip-components=1 \\
                 && rm -Rf %s""";
 
+    /**
+     * Creates a native-image-utils symlink on PATH pointing to
+     * $JAVA_HOME/bin/native-image-configure
+     * 
+     * @see <a href="https://www.graalvm.org/jdk25/security-guide/native-image/sbom/#native-image-utils-tool">native-image-utils
+     *      tool</a>
+     */
+    private static final String NATIVE_IMAGE_UTILS_SYMLINK = "ln -s $JAVA_HOME/bin/native-image-configure /usr/bin/native-image-utils";
+    public static final int NATIVE_IMAGE_UTILS_MIN_JDK_FEATURE = 25;
+
     public MandrelModule(String version, String arch, String javaVersion, String sha) {
         super("mandrel", version + "-java" + javaVersion + "-" + arch);
         this.filename = "mandrel-java%s-linux-%s-%s.tar.gz"
@@ -57,12 +68,17 @@ public class MandrelModule extends AbstractModule {
         Artifact artifact = bc.addArtifact(new Artifact(filename, url, sha));
         String script = TEMPLATE.formatted(
                 MANDREL_HOME, "/tmp/" + artifact.name, MANDREL_HOME, "/tmp/" + artifact.name);
-        bc.setJdkVersion(getJDKVersion(artifact));
-        return List.of(
-                new EnvCommand("JAVA_HOME", MANDREL_HOME, "GRAALVM_HOME", MANDREL_HOME),
-                new MicrodnfCommand("fontconfig", "freetype-devel"),
-                new CopyCommand(artifact, "/tmp/" + artifact.name),
-                new RunCommand(script));
+        final int[] jdkVersion = getJDKVersion(artifact);
+        bc.setJdkVersion(jdkVersion);
+        final List<Command> commands = new ArrayList<>();
+        commands.add(new EnvCommand("JAVA_HOME", MANDREL_HOME, "GRAALVM_HOME", MANDREL_HOME));
+        commands.add(new MicrodnfCommand("fontconfig", "freetype-devel"));
+        commands.add(new CopyCommand(artifact, "/tmp/" + artifact.name));
+        commands.add(new RunCommand(script));
+        if (jdkVersion[0] >= NATIVE_IMAGE_UTILS_MIN_JDK_FEATURE) {
+            commands.add(new RunCommand(NATIVE_IMAGE_UTILS_SYMLINK));
+        }
+        return commands;
     }
 
     public static int[] parseJDKVersion(String version) {

--- a/quarkus-graalvm-builder-image/graalvm.yaml
+++ b/quarkus-graalvm-builder-image/graalvm.yaml
@@ -1,9 +1,11 @@
 images:
-  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-25.0.2
-  - java-version: 25.0.2
-    tags: jdk-25
+  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/graal-25.2.4
+  - graalvm-version: 25i2
+    graalvm-release-tag: graal-25.2.4
+    java-version: 25.0.4
+    tags: jdk-25, 25.2.4-jdk-25
     variants:
       - arch: amd64
-        sha: e0be791c8fda4d03b6b0a0cb824fef3149736170057b3a515252b44419606af0
+        sha: 3f4a89de8eaa96f2ed677f09957c7e872cd8467aad3537f8b5394c1b8c4b942e
       - arch: arm64
-        sha: b4580d9f223d0a4b3a1757e58b18ff4c1db950e67e105fc5cb741457d2384a71
+        sha: 22286f7ecd21b9aedb3226b9bf797469e1bd3eefc491e12ef3dd49b452d230b7

--- a/quarkus-graalvm-builder-image/src/main/java/io/quarkus/images/QuarkusGraalVMBuilder.java
+++ b/quarkus-graalvm-builder-image/src/main/java/io/quarkus/images/QuarkusGraalVMBuilder.java
@@ -10,7 +10,8 @@ import java.util.Map;
 
 public class QuarkusGraalVMBuilder {
 
-    public static Dockerfile getGraalvmDockerFile(String base, String version, String javaVersion, String arch, String sha) {
+    public static Dockerfile getGraalvmDockerFile(String base, String version, String javaVersion, String arch, String sha,
+            String releaseTag) {
         Dockerfile df = Dockerfile.from(base);
         df
                 .user("root")
@@ -21,7 +22,7 @@ public class QuarkusGraalVMBuilder {
                 .module(new QuarkusUserModule())
                 .module(new QuarkusDirectoryModule())
                 .module(new UpxModule(arch))
-                .module(new GraalVMModule(version, arch, javaVersion, sha))
+                .module(new GraalVMModule(version, arch, javaVersion, sha, releaseTag))
                 .env("PATH", "$PATH:$JAVA_HOME/bin")
                 .label("io.k8s.description", "Quarkus.io executable image providing the `native-image` executable.",
                         "io.k8s.display-name", "Quarkus.io executable (GraalVM Native)",
@@ -36,7 +37,7 @@ public class QuarkusGraalVMBuilder {
 
     public static Dockerfile getGraalvmDockerFile(Config.ImageConfig image, Variant variant, String base) {
         return getGraalvmDockerFile(base, image.graalvmVersion(), image.javaVersion(), variant.arch(),
-                variant.sha());
+                variant.sha(), image.graalvmReleaseTag());
     }
 
     public static Map<String, Buildable> collect(Config.ImageConfig image, String base) {

--- a/quarkus-mandrel-builder-image/mandrel.yaml
+++ b/quarkus-mandrel-builder-image/mandrel.yaml
@@ -1,20 +1,20 @@
 images:
-  # https://github.com/graalvm/mandrel/releases/tag/mandrel-23.1.11.0-Final
-  - graalvm-version: 23.1.11.0-Final
+  # https://github.com/graalvm/mandrel/releases/tag/mandrel-23.1.12.0-Final
+  - graalvm-version: 23.1.12.0-Final
     java-version: 21
-    tags: 23.1-java21, 23.1-jdk-21, jdk-21, jdk-21.0.11
+    tags: 23.1-java21, 23.1-jdk-21, jdk-21, jdk-21.0.12
     variants:
-      - sha: 11c27dd5b16b5154336418d63c0bc90781ccf1c7e0ad454126ada2325bd320ca
+      - sha: 71235de50e27cc86ca6511cef4f8dbd342adab4c438da3232a6c50ed2ef963aa
         arch: amd64
-      - sha: 03fe0a47af3a4ca1fa1f7fb38fe6fac07453a2b46ccc9f06631369c6d99197a7
+      - sha: a32645a6e858b64c191f5289dab8ef742c46b47253e72c7748e03fbaaaffc4c1
         arch: arm64
 
-  # https://github.com/graalvm/mandrel/releases/tag/mandrel-25.0.3.0-Final
-  - graalvm-version: 25.0.3.0-Final
+  # https://github.com/graalvm/mandrel/releases/tag/mandrel-25.0.4.0-Final
+  - graalvm-version: 25.0.4.0-Final
     java-version: 25
-    tags: 25.0-java25, 25.0-jdk-25, jdk-25, jdk-25.0.3
+    tags: 25.0-java25, 25.0-jdk-25, jdk-25, jdk-25.0.4
     variants:
-      - sha: 915f986dc71d0fac7e464e900803228d4be6e079d1e71b784e3ed154569e4270
+      - sha: 69b36bea9cd71fd53729cb134c0ff6d2afa46ae8edfec903ce830fbfe718f8c7
         arch: amd64
-      - sha: 7ce2b1cc5bb37b3ab9fc646738405c09343bd25990c9354aa65461077579e469
+      - sha: 67cda0eb413f53d18ed53a0ab1cd1ade35cf87cd5852762af3a1cbf88dfb0abf
         arch: arm64

--- a/quarkus-native-s2i/graalvm.yaml
+++ b/quarkus-native-s2i/graalvm.yaml
@@ -1,9 +1,11 @@
 images:
-  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-25.0.2
-  - java-version: 25.0.2
-    tags: jdk-25
+  # https://github.com/graalvm/graalvm-ce-builds/releases/tag/graal-25.2.4
+  - graalvm-version: 25i2
+    graalvm-release-tag: graal-25.2.4
+    java-version: 25.0.4
+    tags: jdk-25, 25.2.4-jdk-25
     variants:
       - arch: amd64
-        sha: e0be791c8fda4d03b6b0a0cb824fef3149736170057b3a515252b44419606af0
+        sha: 3f4a89de8eaa96f2ed677f09957c7e872cd8467aad3537f8b5394c1b8c4b942e
       - arch: arm64
-        sha: b4580d9f223d0a4b3a1757e58b18ff4c1db950e67e105fc5cb741457d2384a71
+        sha: 22286f7ecd21b9aedb3226b9bf797469e1bd3eefc491e12ef3dd49b452d230b7

--- a/quarkus-native-s2i/src/main/java/io/quarkus/images/QuarkusNativeS2IBuilder.java
+++ b/quarkus-native-s2i/src/main/java/io/quarkus/images/QuarkusNativeS2IBuilder.java
@@ -19,7 +19,7 @@ public class QuarkusNativeS2IBuilder {
                 .module(new UsLangModule())
                 .module(new QuarkusUserModule())
                 .module(new GraalVMModule(config.graalvmVersion, image.arch(), config.javaVersion,
-                        image.sha()))
+                        image.sha(), config.graalvmReleaseTag))
                 .module(new MavenModule())
                 .module(new GradleModule())
                 .module(new NativeS2IModule())


### PR DESCRIPTION
* [842a851](https://github.com/quarkusio/quarkus-images/pull/326/commits/842a851366d50b53a3bd6781078826e8e27b83c4) brings Mandrel July 2026 CPU updates
*  [177af6c](https://github.com/quarkusio/quarkus-images/pull/326/commits/177af6c4bc4180a0742ee4c324665da2b8d05766) addresses https://github.com/quarkusio/quarkus-images/issues/324
```
$ podman run --rm -ti --entrypoint bash quay.io/quarkus/ubi10-quarkus-mandrel-builder-image:25.0.4.0-Final-java25-amd64
[quarkus@3c9097305aba project]$ native-image-utils
No arguments provided.
Use 'native-image-configure help' for usage.
[quarkus@3c9097305aba project]$ native-image-configure
No arguments provided.
Use 'native-image-configure help' for usage.
[quarkus@3c9097305aba project]$ readlink -f /usr/bin/native-image-utils
/opt/mandrel/bin/native-image-configure
```
* [effc72c](https://github.com/quarkusio/quarkus-images/pull/326/commits/effc72c376b5319dbf9e51e9ce3019acbe7b8b64)  commit adds https://github.com/graalvm/graalvm-ce-builds/releases/tag/graal-25.2.4